### PR TITLE
Fix ~20 runtime bugs in v1.2 Workflows (UAT bug hunt)

### DIFF
--- a/src/app/api/v1/deals/[id]/route.ts
+++ b/src/app/api/v1/deals/[id]/route.ts
@@ -31,297 +31,319 @@ interface RouteParams {
 
 export async function GET(request: NextRequest, { params }: RouteParams) {
   return withApiAuth(request, async (req: NextRequest, context: ApiAuthContext) => {
-    const { id } = await params
-    const expand = parseExpand(req)
+    try {
+      const { id } = await params
+      const expand = parseExpand(req)
 
-    // Query deal with ownership check
-    const deal = await db.query.deals.findFirst({
-      where: and(
-        eq(deals.id, id),
-        eq(deals.ownerId, context.userId),
-        isNull(deals.deletedAt)
-      ),
-      with: {
-        ...(expand.has("owner") && {
-          owner: {
-            columns: {
-              id: true,
-              name: true,
-              email: true,
+      // Query deal with ownership check
+      const deal = await db.query.deals.findFirst({
+        where: and(
+          eq(deals.id, id),
+          eq(deals.ownerId, context.userId),
+          isNull(deals.deletedAt)
+        ),
+        with: {
+          ...(expand.has("owner") && {
+            owner: {
+              columns: {
+                id: true,
+                name: true,
+                email: true,
+              },
             },
-          },
-        }),
-        ...(expand.has("organization") && {
-          organization: {
-            columns: {
-              id: true,
-              name: true,
-              website: true,
-              industry: true,
+          }),
+          ...(expand.has("organization") && {
+            organization: {
+              columns: {
+                id: true,
+                name: true,
+                website: true,
+                industry: true,
+              },
             },
-          },
-        }),
-        ...(expand.has("person") && {
-          person: {
-            columns: {
-              id: true,
-              firstName: true,
-              lastName: true,
-              email: true,
+          }),
+          ...(expand.has("person") && {
+            person: {
+              columns: {
+                id: true,
+                firstName: true,
+                lastName: true,
+                email: true,
+              },
             },
-          },
-        }),
-        ...(expand.has("stage") && {
-          stage: {
-            columns: {
-              id: true,
-              name: true,
-              color: true,
-              type: true,
-              position: true,
+          }),
+          ...(expand.has("stage") && {
+            stage: {
+              columns: {
+                id: true,
+                name: true,
+                color: true,
+                type: true,
+                position: true,
+              },
             },
-          },
-        }),
-      },
-    })
+          }),
+        },
+      })
 
-    if (!deal) {
-      return Problems.notFound("Deal")
-    }
+      if (!deal) {
+        return Problems.notFound("Deal")
+      }
 
-    const serialized = serializeDeal(deal)
-    const expanded: Record<string, unknown> = {}
-    if (expand.has("owner") && "owner" in deal && deal.owner) {
-      expanded.owner = deal.owner
-    }
-    if (expand.has("organization") && "organization" in deal && deal.organization) {
-      expanded.organization = deal.organization
-    }
-    if (expand.has("person") && "person" in deal && deal.person) {
-      expanded.person = deal.person
-    }
-    if (expand.has("stage") && "stage" in deal && deal.stage) {
-      expanded.stage = deal.stage
-    }
+      const serialized = serializeDeal(deal)
+      const expanded: Record<string, unknown> = {}
+      if (expand.has("owner") && "owner" in deal && deal.owner) {
+        expanded.owner = deal.owner
+      }
+      if (expand.has("organization") && "organization" in deal && deal.organization) {
+        expanded.organization = deal.organization
+      }
+      if (expand.has("person") && "person" in deal && deal.person) {
+        expanded.person = deal.person
+      }
+      if (expand.has("stage") && "stage" in deal && deal.stage) {
+        expanded.stage = deal.stage
+      }
 
-    const data = Object.keys(expanded).length > 0 ? { ...serialized, ...expanded } : serialized
+      const data = Object.keys(expanded).length > 0 ? { ...serialized, ...expanded } : serialized
 
-    return singleResponse(data)
+      return singleResponse(data)
+    } catch (error) {
+      console.error("GET /api/v1/deals/[id] failed:", error)
+      return Problems.internalError()
+    }
   })
 }
 
 export async function PUT(request: NextRequest, { params }: RouteParams) {
   return withApiAuth(request, async (req: NextRequest, context: ApiAuthContext) => {
-    const { id } = await params
-
-    let body
     try {
-      body = await req.json()
-    } catch {
-      return Problems.validation([
-        { field: "body", code: "invalid_json", message: "Invalid JSON body" },
-      ])
-    }
+      const { id } = await params
 
-    // Validate input
-    const parseResult = updateDealSchema.safeParse(body)
-    if (!parseResult.success) {
-      const errors = parseResult.error.issues.map((issue) => ({
-        field: issue.path.join(".") || "body",
-        code: issue.code,
-        message: issue.message,
-      }))
-      return Problems.validation(errors)
-    }
+      let body
+      try {
+        body = await req.json()
+      } catch {
+        return Problems.validation([
+          { field: "body", code: "invalid_json", message: "Invalid JSON body" },
+        ])
+      }
 
-    // Check deal exists and belongs to user
-    const existing = await db.query.deals.findFirst({
-      where: and(
-        eq(deals.id, id),
-        eq(deals.ownerId, context.userId),
-        isNull(deals.deletedAt)
-      ),
-    })
+      // Validate input
+      const parseResult = updateDealSchema.safeParse(body)
+      if (!parseResult.success) {
+        const errors = parseResult.error.issues.map((issue) => ({
+          field: issue.path.join(".") || "body",
+          code: issue.code,
+          message: issue.message,
+        }))
+        return Problems.validation(errors)
+      }
 
-    if (!existing) {
-      return Problems.notFound("Deal")
-    }
+      // Check deal exists and belongs to user
+      const existing = await db.query.deals.findFirst({
+        where: and(
+          eq(deals.id, id),
+          eq(deals.ownerId, context.userId),
+          isNull(deals.deletedAt)
+        ),
+      })
 
-    const { title, value, stage_id, organization_id, person_id, expected_close_date, notes, custom_fields } = parseResult.data
-    const oldStageId = existing.stageId
+      if (!existing) {
+        return Problems.notFound("Deal")
+      }
 
-    // Verify stage exists and pipeline belongs to user if changing
-    if (stage_id !== undefined && stage_id !== oldStageId) {
-      const stage = await db.query.stages.findFirst({
-        where: eq(stages.id, stage_id),
-        with: {
-          pipeline: {
-            columns: { id: true, ownerId: true },
+      const { title, value, stage_id, organization_id, person_id, expected_close_date, notes, custom_fields } = parseResult.data
+      const oldStageId = existing.stageId
+
+      // Verify stage exists and pipeline belongs to user if changing
+      if (stage_id !== undefined && stage_id !== oldStageId) {
+        const stage = await db.query.stages.findFirst({
+          where: eq(stages.id, stage_id),
+          with: {
+            pipeline: {
+              columns: { id: true, ownerId: true },
+            },
           },
-        },
-      })
+        })
 
-      if (!stage || stage.pipeline.ownerId !== context.userId) {
-        return Problems.validation([
-          { field: "stage_id", code: "invalid_reference", message: "Stage not found or does not belong to user" },
-        ])
+        if (!stage || stage.pipeline.ownerId !== context.userId) {
+          return Problems.validation([
+            { field: "stage_id", code: "invalid_reference", message: "Stage not found or does not belong to user" },
+          ])
+        }
       }
-    }
 
-    // Verify organization exists and belongs to user if provided
-    if (organization_id !== undefined && organization_id !== null) {
-      const org = await db.query.organizations.findFirst({
-        where: and(
-          eq(organizations.id, organization_id),
-          eq(organizations.ownerId, context.userId),
-          isNull(organizations.deletedAt)
-        ),
-      })
+      // Verify organization exists and belongs to user if provided
+      if (organization_id !== undefined && organization_id !== null) {
+        const org = await db.query.organizations.findFirst({
+          where: and(
+            eq(organizations.id, organization_id),
+            eq(organizations.ownerId, context.userId),
+            isNull(organizations.deletedAt)
+          ),
+        })
 
-      if (!org) {
-        return Problems.validation([
-          { field: "organization_id", code: "invalid_reference", message: "Organization not found" },
-        ])
+        if (!org) {
+          return Problems.validation([
+            { field: "organization_id", code: "invalid_reference", message: "Organization not found" },
+          ])
+        }
       }
-    }
 
-    // Verify person exists and belongs to user if provided
-    if (person_id !== undefined && person_id !== null) {
-      const person = await db.query.people.findFirst({
-        where: and(
-          eq(people.id, person_id),
-          eq(people.ownerId, context.userId),
-          isNull(people.deletedAt)
-        ),
-      })
+      // Verify person exists and belongs to user if provided
+      if (person_id !== undefined && person_id !== null) {
+        const person = await db.query.people.findFirst({
+          where: and(
+            eq(people.id, person_id),
+            eq(people.ownerId, context.userId),
+            isNull(people.deletedAt)
+          ),
+        })
 
-      if (!person) {
-        return Problems.validation([
-          { field: "person_id", code: "invalid_reference", message: "Person not found" },
-        ])
+        if (!person) {
+          return Problems.validation([
+            { field: "person_id", code: "invalid_reference", message: "Person not found" },
+          ])
+        }
       }
-    }
 
-    // Build update object and track changed fields
-    const updates: Record<string, unknown> = {
-      updatedAt: new Date(),
-    }
-    const changedFields: string[] = []
-
-    if (title !== undefined) {
-      updates.title = title
-      if (title !== existing.title) changedFields.push("title")
-    }
-    if (value !== undefined) {
-      updates.value = value !== null ? String(value) : null
-      if (String(value) !== existing.value) changedFields.push("value")
-    }
-    if (stage_id !== undefined) {
-      updates.stageId = stage_id
-      if (stage_id !== existing.stageId) changedFields.push("stageId")
-    }
-    if (organization_id !== undefined) {
-      updates.organizationId = organization_id
-      if (organization_id !== existing.organizationId) changedFields.push("organizationId")
-    }
-    if (person_id !== undefined) {
-      updates.personId = person_id
-      if (person_id !== existing.personId) changedFields.push("personId")
-    }
-    if (expected_close_date !== undefined) {
-      updates.expectedCloseDate = expected_close_date ? new Date(expected_close_date) : null
-      changedFields.push("expectedCloseDate")
-    }
-    if (notes !== undefined) {
-      updates.notes = notes
-      if (notes !== existing.notes) changedFields.push("notes")
-    }
-    if (custom_fields !== undefined) {
-      // Merge with existing custom fields
-      updates.customFields = {
-        ...((existing.customFields as Record<string, unknown>) || {}),
-        ...custom_fields,
+      // Build update object and track changed fields
+      const updates: Record<string, unknown> = {
+        updatedAt: new Date(),
       }
-      changedFields.push("customFields")
-    }
+      const changedFields: string[] = []
 
-    // Update deal
-    const [updated] = await db
-      .update(deals)
-      .set(updates)
-      .where(eq(deals.id, id))
-      .returning()
+      if (title !== undefined) {
+        updates.title = title
+        if (title !== existing.title) changedFields.push("title")
+      }
+      if (value !== undefined) {
+        updates.value = value !== null ? String(value) : null
+        if (String(value) !== existing.value) changedFields.push("value")
+      }
+      if (stage_id !== undefined) {
+        updates.stageId = stage_id
+        if (stage_id !== existing.stageId) changedFields.push("stageId")
+      }
+      if (organization_id !== undefined) {
+        updates.organizationId = organization_id
+        if (organization_id !== existing.organizationId) changedFields.push("organizationId")
+      }
+      if (person_id !== undefined) {
+        updates.personId = person_id
+        if (person_id !== existing.personId) changedFields.push("personId")
+      }
+      if (expected_close_date !== undefined) {
+        updates.expectedCloseDate = expected_close_date ? new Date(expected_close_date) : null
+        changedFields.push("expectedCloseDate")
+      }
+      if (notes !== undefined) {
+        updates.notes = notes
+        if (notes !== existing.notes) changedFields.push("notes")
+      }
+      if (custom_fields !== undefined) {
+        // Merge with existing custom fields
+        updates.customFields = {
+          ...((existing.customFields as Record<string, unknown>) || {}),
+          ...custom_fields,
+        }
+        changedFields.push("customFields")
+      }
 
-    const serializedDeal = serializeDeal(updated)
+      // Update deal
+      const [updated] = await db
+        .update(deals)
+        .set(updates)
+        .where(eq(deals.id, id))
+        .returning()
 
-    // Emit stage_changed event if stage changed
-    if (stage_id !== undefined && stage_id !== oldStageId) {
-      const stageChangedPayload: DealStageChangedPayload = {
+      const serializedDeal = serializeDeal(updated)
+
+      // CRM events must carry the raw camelCase row (same shape the mutation
+      // layer in src/lib/mutations/deals.ts emits) so workflow trigger
+      // templates like {{trigger.data.stageId}} behave identically whether
+      // the deal was edited via the UI or the REST API. The HTTP response
+      // body below stays snake_case for API consumers.
+      const eventData = updated as unknown as Record<string, unknown>
+
+      // Emit stage_changed event if stage changed
+      if (stage_id !== undefined && stage_id !== oldStageId) {
+        const stageChangedPayload: DealStageChangedPayload = {
+          entity: "deal",
+          entityId: updated.id,
+          action: "updated",
+          data: eventData,
+          changedFields,
+          userId: context.userId,
+          timestamp: new Date().toISOString(),
+          oldStageId,
+          newStageId: stage_id,
+        }
+        crmBus.emit("deal.stage_changed", stageChangedPayload)
+      }
+
+      // Emit general update event
+      crmBus.emit("deal.updated", {
         entity: "deal",
         entityId: updated.id,
         action: "updated",
-        data: serializedDeal as unknown as Record<string, unknown>,
-        changedFields,
+        data: eventData,
+        changedFields: changedFields.length > 0 ? changedFields : null,
         userId: context.userId,
         timestamp: new Date().toISOString(),
-        oldStageId,
-        newStageId: stage_id,
-      }
-      crmBus.emit("deal.stage_changed", stageChangedPayload)
+      })
+
+      return singleResponse(serializedDeal)
+    } catch (error) {
+      console.error("PUT /api/v1/deals/[id] failed:", error)
+      return Problems.internalError()
     }
-
-    // Emit general update event
-    crmBus.emit("deal.updated", {
-      entity: "deal",
-      entityId: updated.id,
-      action: "updated",
-      data: serializedDeal as unknown as Record<string, unknown>,
-      changedFields: changedFields.length > 0 ? changedFields : null,
-      userId: context.userId,
-      timestamp: new Date().toISOString(),
-    })
-
-    return singleResponse(serializedDeal)
   })
 }
 
 export async function DELETE(request: NextRequest, { params }: RouteParams) {
   return withApiAuth(request, async (req: NextRequest, context: ApiAuthContext) => {
-    const { id } = await params
+    try {
+      const { id } = await params
 
-    // Check deal exists and belongs to user
-    const existing = await db.query.deals.findFirst({
-      where: and(
-        eq(deals.id, id),
-        eq(deals.ownerId, context.userId),
-        isNull(deals.deletedAt)
-      ),
-    })
-
-    if (!existing) {
-      return Problems.notFound("Deal")
-    }
-
-    // Soft delete
-    await db
-      .update(deals)
-      .set({
-        deletedAt: new Date(),
-        updatedAt: new Date(),
+      // Check deal exists and belongs to user
+      const existing = await db.query.deals.findFirst({
+        where: and(
+          eq(deals.id, id),
+          eq(deals.ownerId, context.userId),
+          isNull(deals.deletedAt)
+        ),
       })
-      .where(eq(deals.id, id))
 
-    // Emit CRM event via bus
-    crmBus.emit("deal.deleted", {
-      entity: "deal",
-      entityId: id,
-      action: "deleted",
-      data: { id },
-      changedFields: null,
-      userId: context.userId,
-      timestamp: new Date().toISOString(),
-    })
+      if (!existing) {
+        return Problems.notFound("Deal")
+      }
 
-    return noContentResponse()
+      // Soft delete
+      await db
+        .update(deals)
+        .set({
+          deletedAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .where(eq(deals.id, id))
+
+      // Emit CRM event via bus (same { id } data shape as the mutation layer)
+      crmBus.emit("deal.deleted", {
+        entity: "deal",
+        entityId: id,
+        action: "deleted",
+        data: { id },
+        changedFields: null,
+        userId: context.userId,
+        timestamp: new Date().toISOString(),
+      })
+
+      return noContentResponse()
+    } catch (error) {
+      console.error("DELETE /api/v1/deals/[id] failed:", error)
+      return Problems.internalError()
+    }
   })
 }

--- a/src/app/api/v1/workflows/[id]/route.ts
+++ b/src/app/api/v1/workflows/[id]/route.ts
@@ -4,12 +4,13 @@ import { singleResponse, noContentResponse } from "@/lib/api/response"
 import { Problems } from "@/lib/api/errors"
 import { serializeWorkflow } from "@/lib/api/serialize"
 import { getWorkflow, updateWorkflow, deleteWorkflow } from "@/lib/mutations/workflows"
+import { triggersArraySchema } from "@/lib/triggers/types"
 import { z } from "zod"
 
 const updateWorkflowApiSchema = z.object({
   name: z.string().min(1, "Name is required").max(200).optional(),
   description: z.string().max(2000).nullable().optional(),
-  triggers: z.array(z.record(z.string(), z.unknown())).optional(),
+  triggers: triggersArraySchema.optional(),
   nodes: z.array(z.record(z.string(), z.unknown())).optional(),
   active: z.boolean().optional(),
 })
@@ -20,61 +21,80 @@ interface RouteParams {
 
 export async function GET(request: NextRequest, { params }: RouteParams) {
   return withApiAuth(request, async (req: NextRequest, context: ApiAuthContext) => {
-    const { id } = await params
+    try {
+      const { id } = await params
 
-    const workflow = await getWorkflow(id)
+      // TODO(scoping): getWorkflow (src/lib/mutations/workflows.ts) does not
+      // check ownership, so any valid API key can read any workflow by id.
+      // Ownership scoping must be decided/added at the mutation level to stay
+      // consistent with the UI, which shares these mutations.
+      const workflow = await getWorkflow(id)
 
-    if (!workflow) {
-      return Problems.notFound("Workflow")
+      if (!workflow) {
+        return Problems.notFound("Workflow")
+      }
+
+      return singleResponse(serializeWorkflow(workflow))
+    } catch (error) {
+      console.error("GET /api/v1/workflows/[id] failed:", error)
+      return Problems.internalError()
     }
-
-    return singleResponse(serializeWorkflow(workflow))
   })
 }
 
 export async function PUT(request: NextRequest, { params }: RouteParams) {
   return withApiAuth(request, async (req: NextRequest, context: ApiAuthContext) => {
-    const { id } = await params
-
-    let body
     try {
-      body = await req.json()
-    } catch {
-      return Problems.validation([
-        { field: "body", code: "invalid_json", message: "Invalid JSON body" },
-      ])
+      const { id } = await params
+
+      let body
+      try {
+        body = await req.json()
+      } catch {
+        return Problems.validation([
+          { field: "body", code: "invalid_json", message: "Invalid JSON body" },
+        ])
+      }
+
+      const parseResult = updateWorkflowApiSchema.safeParse(body)
+      if (!parseResult.success) {
+        const errors = parseResult.error.issues.map((issue) => ({
+          field: issue.path.join(".") || "body",
+          code: issue.code,
+          message: issue.message,
+        }))
+        return Problems.validation(errors)
+      }
+
+      const result = await updateWorkflow(id, parseResult.data)
+
+      if (!result.success) {
+        return Problems.notFound("Workflow")
+      }
+
+      return singleResponse(serializeWorkflow(result.workflow))
+    } catch (error) {
+      console.error("PUT /api/v1/workflows/[id] failed:", error)
+      return Problems.internalError()
     }
-
-    const parseResult = updateWorkflowApiSchema.safeParse(body)
-    if (!parseResult.success) {
-      const errors = parseResult.error.issues.map((issue) => ({
-        field: issue.path.join(".") || "body",
-        code: issue.code,
-        message: issue.message,
-      }))
-      return Problems.validation(errors)
-    }
-
-    const result = await updateWorkflow(id, parseResult.data)
-
-    if (!result.success) {
-      return Problems.notFound("Workflow")
-    }
-
-    return singleResponse(serializeWorkflow(result.workflow))
   })
 }
 
 export async function DELETE(request: NextRequest, { params }: RouteParams) {
   return withApiAuth(request, async (req: NextRequest, context: ApiAuthContext) => {
-    const { id } = await params
+    try {
+      const { id } = await params
 
-    const result = await deleteWorkflow(id)
+      const result = await deleteWorkflow(id)
 
-    if (!result.success) {
-      return Problems.notFound("Workflow")
+      if (!result.success) {
+        return Problems.notFound("Workflow")
+      }
+
+      return noContentResponse()
+    } catch (error) {
+      console.error("DELETE /api/v1/workflows/[id] failed:", error)
+      return Problems.internalError()
     }
-
-    return noContentResponse()
   })
 }

--- a/src/app/api/v1/workflows/[id]/run/route.ts
+++ b/src/app/api/v1/workflows/[id]/run/route.ts
@@ -25,6 +25,14 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       return Problems.notFound("Workflow")
     }
 
+    // Inactive workflows cannot be run via the REST trigger, consistent with
+    // every other trigger path (webhook, schedule, CRM events).
+    if (!workflow.active) {
+      return Problems.conflict(
+        "Workflow is not active. Activate the workflow before triggering a run."
+      )
+    }
+
     // Parse optional body for trigger data
     let body: Record<string, unknown> = {}
     try {
@@ -48,6 +56,13 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     })
 
     if (!result.success) {
+      // Covers the race where the workflow was deactivated between the check
+      // above and the trigger call.
+      if (result.code === "workflow_inactive") {
+        return Problems.conflict(
+          "Workflow is not active. Activate the workflow before triggering a run."
+        )
+      }
       return Problems.notFound("Workflow")
     }
 

--- a/src/app/api/v1/workflows/route.ts
+++ b/src/app/api/v1/workflows/route.ts
@@ -5,64 +5,79 @@ import { paginatedResponse, createdResponse } from "@/lib/api/response"
 import { Problems } from "@/lib/api/errors"
 import { serializeWorkflow } from "@/lib/api/serialize"
 import { createWorkflow, listWorkflows } from "@/lib/mutations/workflows"
+import { triggersArraySchema } from "@/lib/triggers/types"
 import { z } from "zod"
 
 const createWorkflowApiSchema = z.object({
   name: z.string().min(1, "Name is required").max(200),
   description: z.string().max(2000).optional().nullable(),
-  triggers: z.array(z.record(z.string(), z.unknown())).optional().default([]),
+  triggers: triggersArraySchema.optional().default([]),
   nodes: z.array(z.record(z.string(), z.unknown())).optional().default([]),
 })
 
 export async function GET(request: NextRequest) {
   return withApiAuth(request, async (req: NextRequest, context: ApiAuthContext) => {
-    const { offset, limit } = parsePagination(req)
+    try {
+      const { offset, limit } = parsePagination(req)
 
-    const result = await listWorkflows({ offset, limit })
+      // TODO(scoping): listWorkflows (src/lib/mutations/workflows.ts) does not
+      // filter by owner, so any valid API key sees every workflow. Ownership
+      // scoping must be added at the mutation level (it also affects the UI
+      // list); filtering here after the fact would break pagination totals.
+      const result = await listWorkflows({ offset, limit })
 
-    const data = result.workflows.map(serializeWorkflow)
+      const data = result.workflows.map(serializeWorkflow)
 
-    return paginatedResponse(data, result.total, offset, limit)
+      return paginatedResponse(data, result.total, offset, limit)
+    } catch (error) {
+      console.error("GET /api/v1/workflows failed:", error)
+      return Problems.internalError()
+    }
   })
 }
 
 export async function POST(request: NextRequest) {
   return withApiAuth(request, async (req: NextRequest, context: ApiAuthContext) => {
-    let body
     try {
-      body = await req.json()
-    } catch {
-      return Problems.validation([
-        { field: "body", code: "invalid_json", message: "Invalid JSON body" },
-      ])
+      let body
+      try {
+        body = await req.json()
+      } catch {
+        return Problems.validation([
+          { field: "body", code: "invalid_json", message: "Invalid JSON body" },
+        ])
+      }
+
+      const parseResult = createWorkflowApiSchema.safeParse(body)
+      if (!parseResult.success) {
+        const errors = parseResult.error.issues.map((issue) => ({
+          field: issue.path.join(".") || "body",
+          code: issue.code,
+          message: issue.message,
+        }))
+        return Problems.validation(errors)
+      }
+
+      const { name, description, triggers, nodes } = parseResult.data
+
+      const result = await createWorkflow({
+        name,
+        description: description ?? undefined,
+        triggers,
+        nodes,
+        createdBy: context.userId,
+      })
+
+      if (!result.success) {
+        return Problems.validation([
+          { field: "body", code: "mutation_error", message: result.error },
+        ])
+      }
+
+      return createdResponse(serializeWorkflow(result.workflow))
+    } catch (error) {
+      console.error("POST /api/v1/workflows failed:", error)
+      return Problems.internalError()
     }
-
-    const parseResult = createWorkflowApiSchema.safeParse(body)
-    if (!parseResult.success) {
-      const errors = parseResult.error.issues.map((issue) => ({
-        field: issue.path.join(".") || "body",
-        code: issue.code,
-        message: issue.message,
-      }))
-      return Problems.validation(errors)
-    }
-
-    const { name, description, triggers, nodes } = parseResult.data
-
-    const result = await createWorkflow({
-      name,
-      description: description ?? undefined,
-      triggers,
-      nodes,
-      createdBy: context.userId,
-    })
-
-    if (!result.success) {
-      return Problems.validation([
-        { field: "body", code: "mutation_error", message: result.error },
-      ])
-    }
-
-    return createdResponse(serializeWorkflow(result.workflow))
   })
 }

--- a/src/app/api/webhooks/in/[workflowId]/[secret]/route.ts
+++ b/src/app/api/webhooks/in/[workflowId]/[secret]/route.ts
@@ -3,7 +3,7 @@ import { db } from "@/db"
 import { workflows } from "@/db/schema/workflows"
 import { eq } from "drizzle-orm"
 import { verifyWebhookSecret } from "@/lib/triggers/webhook-secret"
-import { createWorkflowRun } from "@/lib/triggers/create-run"
+import { createWorkflowRun, claimWorkflowRun } from "@/lib/triggers/create-run"
 import {
   waitForWebhookResponse,
   hasWebhookResponseNode,
@@ -38,18 +38,29 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json({ error: "Not found" }, { status: 404 })
   }
 
-  // Find webhook trigger in triggers array
+  // Match the provided secret against ANY webhook trigger in the array.
+  // A workflow can have multiple webhook triggers, each with its own secret;
+  // every candidate is checked with a timing-safe comparison. We deliberately
+  // do not break out of the loop early so the amount of comparison work does
+  // not depend on which trigger (if any) matched.
   const triggers = (workflow.triggers ?? []) as Array<Record<string, unknown>>
-  const webhookTriggerIndex = triggers.findIndex((t) => t.type === "webhook")
-  const webhookTrigger = webhookTriggerIndex >= 0 ? triggers[webhookTriggerIndex] : null
+  let matchedTriggerIndex = -1
+  for (let i = 0; i < triggers.length; i++) {
+    const trigger = triggers[i]
+    if (trigger.type !== "webhook") continue
 
-  if (!webhookTrigger) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 })
+    const storedSecret = trigger.secret as string | undefined
+    if (
+      storedSecret &&
+      verifyWebhookSecret(secret, storedSecret) &&
+      matchedTriggerIndex === -1
+    ) {
+      matchedTriggerIndex = i
+    }
   }
 
-  // Verify secret with timing-safe comparison
-  const storedSecret = webhookTrigger.secret as string
-  if (!storedSecret || !verifyWebhookSecret(secret, storedSecret)) {
+  // No webhook trigger or no matching secret: 404 (no information leakage)
+  if (matchedTriggerIndex === -1) {
     return NextResponse.json({ error: "Not found" }, { status: 404 })
   }
 
@@ -67,7 +78,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   // Build trigger envelope
   const envelope: TriggerEnvelope = {
     trigger_type: "webhook",
-    trigger_id: String(webhookTriggerIndex),
+    trigger_id: String(matchedTriggerIndex),
     timestamp: new Date().toISOString(),
     data: {
       body,
@@ -84,6 +95,21 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   // Check if workflow has a webhook_response node for synchronous execution
   const workflowNodes = (workflow.nodes ?? []) as unknown[]
   if (hasWebhookResponseNode(workflowNodes)) {
+    // Atomically claim the run (pending -> running) BEFORE executing it here.
+    // The execution processor polls every few seconds and claims any pending
+    // run with the same status flip; without this claim both sides could
+    // execute the run, duplicating steps and CRM/HTTP side effects.
+    const claimed = await claimWorkflowRun(run.id)
+    if (!claimed) {
+      // Not claimable: either the processor already grabbed it (it will
+      // execute the run) or the run was created in a non-pending state
+      // (e.g. failed by the recursion guard). Do not execute it here.
+      return NextResponse.json(
+        { ok: true, run_id: run.id },
+        { status: 200 }
+      )
+    }
+
     // Register pending response BEFORE executing so the handler can resolve it
     const responsePromise = waitForWebhookResponse(run.id, 30_000)
 

--- a/src/app/workflows/[id]/edit/components/config-forms/crm-config.tsx
+++ b/src/app/workflows/[id]/edit/components/config-forms/crm-config.tsx
@@ -17,6 +17,15 @@ import { VariableInput } from "../variable-picker/variable-field"
 const CRM_ENTITIES = ["deal", "person", "organization", "activity"] as const
 const CRM_OPERATIONS = ["create", "update", "delete"] as const
 
+// Mirrors the lookup whitelist in src/lib/execution/actions/crm.ts
+// (lookupDefs) — the handler is the source of truth.
+const CRM_LOOKUP_FIELDS: Record<string, string[]> = {
+  deal: ["title"],
+  person: ["email", "firstName"],
+  organization: ["name"],
+  activity: ["title"],
+}
+
 interface Props {
   nodeId: string
   config: Record<string, unknown>
@@ -34,6 +43,7 @@ export function CrmConfig({ nodeId, config }: Props) {
 
   const mappingEntries = Object.entries(fieldMapping)
   const needsTarget = operation === "update" || operation === "delete"
+  const lookupFieldOptions = CRM_LOOKUP_FIELDS[entity] ?? []
 
   const update = (patch: Record<string, unknown>) => {
     updateNodeConfig(nodeId, patch)
@@ -61,7 +71,20 @@ export function CrmConfig({ nodeId, config }: Props) {
       {/* Entity */}
       <div>
         <Label className="text-xs">Entity</Label>
-        <Select value={entity} onValueChange={(v) => update({ entity: v })}>
+        <Select
+          value={entity}
+          onValueChange={(v) => {
+            const patch: Record<string, unknown> = { entity: v }
+            // Clear lookupField if it is not supported by the new entity
+            if (
+              lookupField &&
+              !(CRM_LOOKUP_FIELDS[v] ?? []).includes(lookupField)
+            ) {
+              patch.lookupField = ""
+            }
+            update(patch)
+          }}
+        >
           <SelectTrigger>
             <SelectValue />
           </SelectTrigger>
@@ -111,11 +134,21 @@ export function CrmConfig({ nodeId, config }: Props) {
           <p className="text-center text-xs text-muted-foreground">-- or --</p>
           <div>
             <Label className="text-xs">Lookup Field</Label>
-            <Input
-              value={lookupField}
-              onChange={(e) => update({ lookupField: e.target.value })}
-              placeholder="e.g. email"
-            />
+            <Select
+              value={lookupField || undefined}
+              onValueChange={(v) => update({ lookupField: v })}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select field..." />
+              </SelectTrigger>
+              <SelectContent>
+                {lookupFieldOptions.map((f) => (
+                  <SelectItem key={f} value={f}>
+                    {f}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
           <div>
             <Label className="text-xs">Lookup Value</Label>

--- a/src/app/workflows/[id]/edit/components/config-forms/http-config.tsx
+++ b/src/app/workflows/[id]/edit/components/config-forms/http-config.tsx
@@ -63,7 +63,8 @@ export function HttpConfig({ nodeId, config }: Props) {
   const retryCount = (config.retryCount as number) ?? 0
 
   const headerEntries = Object.entries(headers)
-  const showBody = ["POST", "PUT", "PATCH"].includes(method)
+  const BODY_METHODS = ["POST", "PUT", "PATCH"]
+  const showBody = BODY_METHODS.includes(method)
 
   // Custom templates state
   const [customTemplates, setCustomTemplates] = useState<HttpTemplateRecord[]>([])
@@ -122,7 +123,7 @@ export function HttpConfig({ nodeId, config }: Props) {
         method: cfg.method,
         url: cfg.url,
         headers: cfg.headers,
-        body: cfg.body,
+        body: cfg.body ?? "",
         timeout: cfg.timeout,
         retryCount: cfg.retryCount,
       })
@@ -261,7 +262,18 @@ export function HttpConfig({ nodeId, config }: Props) {
       {/* Method */}
       <div>
         <Label className="text-xs">Method</Label>
-        <Select value={method} onValueChange={(v) => update({ method: v })}>
+        <Select
+          value={method}
+          onValueChange={(v) => {
+            const patch: Record<string, unknown> = { method: v }
+            // Clear stale body when switching to a method whose Body field
+            // is hidden (GET/HEAD must never carry a body)
+            if (!BODY_METHODS.includes(v) && body) {
+              patch.body = ""
+            }
+            update(patch)
+          }}
+        >
           <SelectTrigger>
             <SelectValue />
           </SelectTrigger>

--- a/src/app/workflows/[id]/edit/components/config-forms/transform-config.tsx
+++ b/src/app/workflows/[id]/edit/components/config-forms/transform-config.tsx
@@ -32,18 +32,41 @@ export function TransformConfig({ nodeId, config }: Props) {
         <p className="mb-2 text-xs font-semibold">Available Globals</p>
         <ul className="space-y-1 text-xs text-muted-foreground">
           <li>
-            <code className="font-mono text-foreground">input</code> -- Data
-            from the previous node
+            <code className="font-mono text-foreground">input</code> --{" "}
+            <code className="font-mono">{"{ trigger, nodes }"}</code>. Trigger
+            data is at{" "}
+            <code className="font-mono">input.trigger.data</code>; outputs of
+            earlier nodes are at{" "}
+            <code className="font-mono">
+              input.nodes.&lt;nodeId&gt;.output
+            </code>
           </li>
           <li>
-            <code className="font-mono text-foreground">output</code> --
-            Accumulated outputs from all prior nodes
+            <code className="font-mono text-foreground">console.log(...)</code>{" "}
+            -- Logged messages are captured and returned with the node output
           </li>
           <li>
-            <code className="font-mono text-foreground">helpers</code> --
-            Utility functions (pick, omit, get, set, capitalize, etc.)
+            <code className="font-mono text-foreground">MATH</code> -- abs,
+            ceil, floor, round, max, min, sqrt, pow, log, log10, exp
+          </li>
+          <li>
+            <code className="font-mono text-foreground">TEXT</code> -- upper,
+            lower, trim, length, len, substring, replace, contains, startsWith,
+            endsWith, split, join, left, right, concat
+          </li>
+          <li>
+            <code className="font-mono text-foreground">DATE</code> -- today,
+            now, addDays, addMonths, diffDays, format, parseDate, year, month,
+            day, days
+          </li>
+          <li>
+            <code className="font-mono text-foreground">LOGIC</code> -- if,
+            and, or, not, isBlank, isNumber
           </li>
         </ul>
+        <p className="mt-2 text-xs text-muted-foreground">
+          Your code must <code className="font-mono">return</code> an object.
+        </p>
       </div>
     </div>
   )

--- a/src/app/workflows/[id]/edit/components/config-forms/webhook-response-config.tsx
+++ b/src/app/workflows/[id]/edit/components/config-forms/webhook-response-config.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useEffect, useState } from "react"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { useEditorStore } from "../../lib/editor-store"
@@ -10,14 +11,62 @@ interface Props {
   config: Record<string, unknown>
 }
 
+/** Stringify the stored body (object) for display in the textarea. */
+function bodyToText(body: unknown): string {
+  if (body == null) return ""
+  if (typeof body === "string") return body
+  try {
+    return JSON.stringify(body, null, 2)
+  } catch {
+    return ""
+  }
+}
+
 export function WebhookResponseConfig({ nodeId, config }: Props) {
   const updateNodeConfig = useEditorStore((s) => s.updateNodeConfig)
 
   const statusCode = (config.statusCode as number) ?? 200
-  const body = (config.body as string) ?? ""
+
+  // Local text state for the textarea; the stored config.body is always
+  // a parsed JSON object (or undefined), never a raw string.
+  const [bodyText, setBodyText] = useState(() => bodyToText(config.body))
+  const [bodyInvalid, setBodyInvalid] = useState(false)
+
+  // Reset local text when switching to a different node.
+  useEffect(() => {
+    setBodyText(bodyToText(config.body))
+    setBodyInvalid(false)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nodeId])
 
   const update = (patch: Record<string, unknown>) => {
     updateNodeConfig(nodeId, patch)
+  }
+
+  const handleBodyChange = (v: string) => {
+    setBodyText(v)
+
+    if (v.trim() === "") {
+      // Empty input: omit the body entirely.
+      setBodyInvalid(false)
+      update({ body: undefined })
+      return
+    }
+
+    try {
+      const parsed: unknown = JSON.parse(v)
+      if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+        setBodyInvalid(false)
+        update({ body: parsed })
+        return
+      }
+    } catch {
+      // fall through to invalid state
+    }
+
+    // Not a valid JSON object: don't store the raw string (the execution
+    // handler expects an object). Keep the last valid value and hint.
+    setBodyInvalid(true)
   }
 
   return (
@@ -43,12 +92,18 @@ export function WebhookResponseConfig({ nodeId, config }: Props) {
       <div>
         <Label className="text-xs">Response Body (JSON)</Label>
         <VariableTextarea
-          value={typeof body === "string" ? body : JSON.stringify(body, null, 2)}
-          onChange={(v) => update({ body: v })}
+          value={bodyText}
+          onChange={handleBodyChange}
           nodeId={nodeId}
           placeholder='{"success": true, "message": "Processed"}'
           className="min-h-[120px] font-mono text-xs"
         />
+        {bodyInvalid && (
+          <p className="mt-1 text-xs text-destructive">
+            Invalid JSON — must be a JSON object, e.g.{" "}
+            {'{"success": true}'}. Changes are not saved until valid.
+          </p>
+        )}
       </div>
     </div>
   )

--- a/src/app/workflows/[id]/edit/lib/graph-mutations.ts
+++ b/src/app/workflows/[id]/edit/lib/graph-mutations.ts
@@ -7,6 +7,7 @@ import type {
   DelayNode,
   SplitNode,
 } from "@/lib/execution/types"
+import { defaultActionConfig } from "@/lib/execution/actions/types"
 
 /**
  * Insert a new node after the specified node in the chain.
@@ -183,7 +184,10 @@ export function createNewNode(
         id,
         type: "action",
         label: actionType ? actionType.replace(/_/g, " ") : "New Action",
-        config: { actionType: actionType || "http_request" },
+        // Structurally valid minimal config: every key the schema requires
+        // exists with a safe empty value, so the node can be saved before
+        // the user configures it and runtime never reads `undefined`.
+        config: defaultActionConfig(actionType || "http_request"),
         nextNodeId: null,
       } as ActionNode
 

--- a/src/lib/api/pagination.ts
+++ b/src/lib/api/pagination.ts
@@ -1,10 +1,18 @@
 import { NextRequest } from "next/server"
 
 export const DEFAULT_PAGE_SIZE = 50
+export const MAX_PAGE_SIZE = 100
 
 /**
  * Parse pagination parameters from request query string
- * 
+ *
+ * - `offset`: non-negative integer; NaN/negative values fall back to 0
+ * - `limit`: integer clamped to [1, MAX_PAGE_SIZE]; NaN falls back to DEFAULT_PAGE_SIZE
+ *
+ * Guarantees finite integers so invalid input (e.g. `?limit=abc`,
+ * `?limit=10000000`) can never reach Drizzle `.limit()/.offset()` as NaN
+ * or dump entire tables.
+ *
  * @param request - The incoming Next.js request
  * @returns Pagination params with offset and limit
  */
@@ -12,7 +20,14 @@ export function parsePagination(
   request: NextRequest
 ): { offset: number; limit: number } {
   const { searchParams } = request.nextUrl
-  const offset = Math.max(0, parseInt(searchParams.get("offset") || "0", 10))
-  const limit = Math.max(1, parseInt(searchParams.get("limit") || String(DEFAULT_PAGE_SIZE), 10))
+
+  const rawOffset = parseInt(searchParams.get("offset") ?? "", 10)
+  const rawLimit = parseInt(searchParams.get("limit") ?? "", 10)
+
+  const offset = Number.isNaN(rawOffset) ? 0 : Math.max(0, rawOffset)
+  const limit = Number.isNaN(rawLimit)
+    ? DEFAULT_PAGE_SIZE
+    : Math.min(MAX_PAGE_SIZE, Math.max(1, rawLimit))
+
   return { offset, limit }
 }

--- a/src/lib/api/serialize.ts
+++ b/src/lib/api/serialize.ts
@@ -156,15 +156,34 @@ export function serializeCustomFieldDefinition(cfd: CustomFieldDefinition) {
 }
 
 /**
+ * Strip webhook secrets from trigger configs before returning them via the API.
+ * The inbound webhook URL secret is a credential — exposing it lets any valid
+ * API key enumerate every workflow's inbound webhook secret. Clients that need
+ * a new secret should use the secret regeneration endpoint.
+ */
+function redactTriggerSecrets(
+  triggers: Record<string, unknown>[] | null | undefined
+): Record<string, unknown>[] {
+  if (!Array.isArray(triggers)) return []
+  return triggers.map((trigger) => {
+    if (trigger && trigger.type === "webhook" && "secret" in trigger) {
+      const { secret: _secret, ...rest } = trigger
+      return rest
+    }
+    return trigger
+  })
+}
+
+/**
  * Serialize workflow to snake_case API format
- * Includes full trigger and nodes graph
+ * Includes full trigger and nodes graph (webhook secrets redacted)
  */
 export function serializeWorkflow(workflow: Workflow) {
   return {
     id: workflow.id,
     name: workflow.name,
     description: workflow.description,
-    triggers: workflow.triggers,
+    triggers: redactTriggerSecrets(workflow.triggers),
     nodes: workflow.nodes,
     active: workflow.active,
     created_by: workflow.createdBy,

--- a/src/lib/execution/actions/__tests__/crm.test.ts
+++ b/src/lib/execution/actions/__tests__/crm.test.ts
@@ -220,10 +220,185 @@ describe("CRM action handler", () => {
     expect(mockCreateActivity).toHaveBeenCalledWith({
       title: "Follow up on New Deal",
       typeId: "type-1",
-      dueDate: "2026-04-01",
+      // dueDate is coerced from string to Date (activitySchema expects z.date())
+      dueDate: new Date("2026-04-01"),
       userId: "user-abc",
     })
     expect(result.output).toMatchObject({ success: true, id: "act-new" })
+  })
+
+  describe("fieldMapping type coercion", () => {
+    it("coerces numeric string to number for deal value on create", async () => {
+      mockCreateDeal.mockResolvedValue({ success: true, id: "d1", deal: {} })
+
+      await executeAction(
+        "crm_action",
+        {
+          actionType: "crm_action",
+          entity: "deal",
+          operation: "create",
+          fieldMapping: {
+            title: "Big Deal",
+            stageId: "stage-1",
+            value: "9999",
+          },
+        },
+        makeContext(),
+        "run-1"
+      )
+
+      expect(mockCreateDeal).toHaveBeenCalledWith({
+        title: "Big Deal",
+        stageId: "stage-1",
+        value: 9999,
+        userId: "user-abc",
+      })
+    })
+
+    it("coerces numeric string to number for deal value on update", async () => {
+      mockUpdateDeal.mockResolvedValue({ success: true })
+
+      await executeAction(
+        "crm_action",
+        {
+          actionType: "crm_action",
+          entity: "deal",
+          operation: "update",
+          fieldMapping: { value: "9999" },
+          targetId: "deal-1",
+        },
+        makeContext(),
+        "run-1"
+      )
+
+      expect(mockUpdateDeal).toHaveBeenCalledWith(
+        "deal-1",
+        { value: 9999 },
+        "user-abc"
+      )
+    })
+
+    it("coerces interpolated numeric value", async () => {
+      mockUpdateDeal.mockResolvedValue({ success: true })
+
+      await executeAction(
+        "crm_action",
+        {
+          actionType: "crm_action",
+          entity: "deal",
+          operation: "update",
+          fieldMapping: { value: "{{trigger.data.amount}}" },
+          targetId: "deal-1",
+        },
+        makeContext({
+          trigger: { type: "deal.created", data: { amount: 1234.5 } },
+        }),
+        "run-1"
+      )
+
+      expect(mockUpdateDeal).toHaveBeenCalledWith(
+        "deal-1",
+        { value: 1234.5 },
+        "user-abc"
+      )
+    })
+
+    it("coerces date string to Date for deal expectedCloseDate", async () => {
+      mockUpdateDeal.mockResolvedValue({ success: true })
+
+      await executeAction(
+        "crm_action",
+        {
+          actionType: "crm_action",
+          entity: "deal",
+          operation: "update",
+          fieldMapping: { expectedCloseDate: "2026-09-01" },
+          targetId: "deal-1",
+        },
+        makeContext(),
+        "run-1"
+      )
+
+      expect(mockUpdateDeal).toHaveBeenCalledWith(
+        "deal-1",
+        { expectedCloseDate: new Date("2026-09-01") },
+        "user-abc"
+      )
+    })
+
+    it("does not coerce string fields (title stays string)", async () => {
+      mockUpdateDeal.mockResolvedValue({ success: true })
+
+      await executeAction(
+        "crm_action",
+        {
+          actionType: "crm_action",
+          entity: "deal",
+          operation: "update",
+          fieldMapping: { title: "9999" },
+          targetId: "deal-1",
+        },
+        makeContext(),
+        "run-1"
+      )
+
+      expect(mockUpdateDeal).toHaveBeenCalledWith(
+        "deal-1",
+        { title: "9999" },
+        "user-abc"
+      )
+    })
+
+    it("omits empty-string values for typed fields", async () => {
+      mockUpdateDeal.mockResolvedValue({ success: true })
+
+      await executeAction(
+        "crm_action",
+        {
+          actionType: "crm_action",
+          entity: "deal",
+          operation: "update",
+          fieldMapping: { value: "", title: "Kept" },
+          targetId: "deal-1",
+        },
+        makeContext(),
+        "run-1"
+      )
+
+      expect(mockUpdateDeal).toHaveBeenCalledWith(
+        "deal-1",
+        { title: "Kept" },
+        "user-abc"
+      )
+    })
+
+    it("leaves non-numeric strings unchanged so validation reports them", async () => {
+      mockUpdateDeal.mockResolvedValue({
+        success: false,
+        error: "Invalid input",
+      })
+
+      await expect(
+        executeAction(
+          "crm_action",
+          {
+            actionType: "crm_action",
+            entity: "deal",
+            operation: "update",
+            fieldMapping: { value: "not-a-number" },
+            targetId: "deal-1",
+          },
+          makeContext(),
+          "run-1"
+        )
+      ).rejects.toThrow("Invalid input")
+
+      expect(mockUpdateDeal).toHaveBeenCalledWith(
+        "deal-1",
+        { value: "not-a-number" },
+        "user-abc"
+      )
+    })
   })
 
   it("throws on mutation failure", async () => {

--- a/src/lib/execution/actions/__tests__/http.test.ts
+++ b/src/lib/execution/actions/__tests__/http.test.ts
@@ -151,6 +151,116 @@ describe("HTTP action handler", () => {
     expect(init.headers["content-type"]).toBe("application/json")
   })
 
+  it("GET with empty-string body omits body (built-in GET templates ship body: '')", async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-type": "application/json" }),
+      json: () => Promise.resolve({ ok: true }),
+      text: () => Promise.resolve('{"ok":true}'),
+    })
+
+    await executeAction(
+      "http_request",
+      {
+        actionType: "http_request",
+        method: "GET",
+        url: "https://api.example.com/forms/responses",
+        headers: { Authorization: "Bearer token" },
+        body: "",
+        timeout: 30,
+        retryCount: 0,
+      },
+      makeContext(),
+      "run-1"
+    )
+
+    const [, init] = fetchSpy.mock.calls[0]
+    expect(init.body).toBeUndefined()
+    // No auto Content-Type since there is no body
+    expect(init.headers["content-type"]).toBeUndefined()
+  })
+
+  it("GET with non-empty body never attaches it (fetch forbids GET/HEAD bodies)", async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-type": "application/json" }),
+      json: () => Promise.resolve({}),
+      text: () => Promise.resolve("{}"),
+    })
+
+    await executeAction(
+      "http_request",
+      {
+        actionType: "http_request",
+        method: "GET",
+        url: "https://api.example.com/data",
+        body: '{"stale":"body"}',
+        timeout: 30,
+        retryCount: 0,
+      },
+      makeContext(),
+      "run-1"
+    )
+
+    const [, init] = fetchSpy.mock.calls[0]
+    expect(init.body).toBeUndefined()
+  })
+
+  it("HEAD request omits body", async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({}),
+      text: () => Promise.resolve(""),
+    })
+
+    await executeAction(
+      "http_request",
+      {
+        actionType: "http_request",
+        method: "HEAD",
+        url: "https://api.example.com/data",
+        body: '{"stale":"body"}',
+        timeout: 30,
+        retryCount: 0,
+      },
+      makeContext(),
+      "run-1"
+    )
+
+    const [, init] = fetchSpy.mock.calls[0]
+    expect(init.body).toBeUndefined()
+  })
+
+  it("POST with empty-string body sends no body", async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-type": "application/json" }),
+      json: () => Promise.resolve({}),
+      text: () => Promise.resolve("{}"),
+    })
+
+    await executeAction(
+      "http_request",
+      {
+        actionType: "http_request",
+        method: "POST",
+        url: "https://api.example.com/data",
+        body: "",
+        timeout: 30,
+        retryCount: 0,
+      },
+      makeContext(),
+      "run-1"
+    )
+
+    const [, init] = fetchSpy.mock.calls[0]
+    expect(init.body).toBeUndefined()
+  })
+
   it("interpolates variables in URL", async () => {
     fetchSpy.mockResolvedValue({
       ok: true,

--- a/src/lib/execution/actions/crm.ts
+++ b/src/lib/execution/actions/crm.ts
@@ -91,6 +91,81 @@ const lookupDefs: Record<string, LookupDef> = {
   },
 }
 
+// ---- Field type coercion ----
+
+type CoercibleFieldType = "number" | "date" | "boolean"
+
+/**
+ * Known non-string fields per entity, mirroring the Zod schemas in
+ * src/lib/mutations/*.ts. fieldMapping values arrive as strings (editor
+ * text inputs / interpolation), so they must be coerced before validation.
+ */
+const crmFieldTypes: Record<string, Record<string, CoercibleFieldType>> = {
+  deal: {
+    value: "number", // dealSchema: z.number().min(0).optional().nullable()
+    expectedCloseDate: "date", // dealSchema: z.date().optional().nullable()
+  },
+  person: {},
+  organization: {},
+  activity: {
+    dueDate: "date", // activitySchema: z.date()
+  },
+}
+
+/**
+ * Coerce a single interpolated value to the target field's expected type.
+ * Values that cannot be coerced are returned unchanged so Zod validation
+ * surfaces a meaningful error.
+ */
+function coerceValue(value: unknown, type: CoercibleFieldType): unknown {
+  if (typeof value !== "string") return value
+  const trimmed = value.trim()
+
+  switch (type) {
+    case "number": {
+      const num = Number(trimmed)
+      return Number.isNaN(num) ? value : num
+    }
+    case "date": {
+      const date = new Date(trimmed)
+      return Number.isNaN(date.getTime()) ? value : date
+    }
+    case "boolean": {
+      if (/^(true|1|yes)$/i.test(trimmed)) return true
+      if (/^(false|0|no)$/i.test(trimmed)) return false
+      return value
+    }
+  }
+}
+
+/**
+ * Coerce interpolated fieldMapping values to the types the entity's Zod
+ * schema expects. String fields pass through untouched. Empty strings for
+ * typed (number/date/boolean) fields are omitted so they don't fail
+ * validation or clobber existing data.
+ */
+function coerceFieldMapping(
+  entity: string,
+  fields: Record<string, unknown>
+): Record<string, unknown> {
+  const typeMap = crmFieldTypes[entity] ?? {}
+  const result: Record<string, unknown> = {}
+
+  for (const [key, value] of Object.entries(fields)) {
+    const type = typeMap[key]
+    if (!type) {
+      result[key] = value
+      continue
+    }
+    if (typeof value === "string" && value.trim() === "") {
+      continue // omit empty values for typed fields
+    }
+    result[key] = coerceValue(value, type)
+  }
+
+  return result
+}
+
 /**
  * Resolve entity ID via field lookup.
  * Uses ilike for case-insensitive text matching.
@@ -175,7 +250,10 @@ async function handleCrmAction(
   }
 
   const depth = getCurrentExecutionDepth()
-  const interpolatedFields = interpolateDeep(fieldMapping, context)
+  const interpolatedFields = coerceFieldMapping(
+    entity,
+    interpolateDeep(fieldMapping, context)
+  )
 
   switch (operation) {
     case "create": {

--- a/src/lib/execution/actions/http.ts
+++ b/src/lib/execution/actions/http.ts
@@ -65,9 +65,11 @@ async function httpHandler(
   // SSRF check
   await validateUrl(url)
 
-  // Build body
+  // Build body — never attach one for GET/HEAD (fetch/undici throws
+  // "Request with GET/HEAD method cannot have body"), and skip empty strings.
+  const methodAllowsBody = !["GET", "HEAD"].includes(method.toUpperCase())
   let body: string | undefined
-  if (rawBody !== undefined) {
+  if (methodAllowsBody && rawBody !== undefined && rawBody !== "") {
     if (typeof rawBody === "string") {
       body = interpolate(rawBody, context)
     } else {

--- a/src/lib/execution/actions/types.ts
+++ b/src/lib/execution/actions/types.ts
@@ -91,3 +91,103 @@ export function validateActionConfig(config: Record<string, unknown>): ActionTyp
   }
   return schema.parse(config) as ActionType
 }
+
+// -- Structural (save-time) validation --
+//
+// Policy: workflow saves validate every action node's config STRUCTURALLY on
+// every save (createWorkflow/updateWorkflow) — the actionType must be known,
+// all required keys must exist, and every value must have the correct
+// type/enum. Business completeness (e.g. a non-empty url or subject) is NOT
+// enforced at save time, so a freshly created node with safe-empty defaults
+// can be saved before the user fills in the form. The strict schemas above
+// remain the contract for execution time.
+const structuralSchemaMap: Record<string, z.ZodSchema> = {
+  http_request: httpRequestConfigSchema.extend({ url: z.string() }),
+  crm_action: crmActionConfigSchema,
+  email: emailConfigSchema.extend({
+    subject: z.string(),
+    body: z.string(),
+  }),
+  notification: notificationConfigSchema.extend({ message: z.string() }),
+  javascript_transform: jsTransformConfigSchema.extend({ code: z.string() }),
+  webhook_response: webhookResponseConfigSchema,
+}
+
+export type ActionConfigValidationResult =
+  | { success: true }
+  | { success: false; error: string }
+
+/**
+ * Non-throwing structural validation of an action config: correct shape,
+ * keys, and value types for its actionType, but empty-string placeholders
+ * are allowed. Used by workflow save mutations.
+ */
+export function validateActionConfigStructure(
+  config: Record<string, unknown>
+): ActionConfigValidationResult {
+  const actionType = config.actionType
+  if (typeof actionType !== "string" || actionType.length === 0) {
+    return { success: false, error: "Missing action type" }
+  }
+  const schema = structuralSchemaMap[actionType]
+  if (!schema) {
+    return { success: false, error: `Unknown action type: ${actionType}` }
+  }
+  const result = schema.safeParse(config)
+  if (!result.success) {
+    const issue = result.error.issues[0]
+    const path = issue?.path.join(".")
+    const message = issue?.message ?? "Invalid config"
+    return { success: false, error: path ? `${path}: ${message}` : message }
+  }
+  return { success: true }
+}
+
+// -- Default configs for new action nodes --
+//
+// Every key required by the structural schema is present with a safe empty
+// value, so a brand-new node saves cleanly and the execution engine never
+// reads `undefined` where a string/number/array is expected.
+const defaultConfigMap: Record<string, Record<string, unknown>> = {
+  http_request: {
+    actionType: "http_request",
+    method: "GET",
+    url: "",
+    timeout: 30,
+    retryCount: 0,
+  },
+  crm_action: {
+    actionType: "crm_action",
+    entity: "deal",
+    operation: "create",
+    fieldMapping: {},
+  },
+  email: {
+    actionType: "email",
+    recipients: [],
+    subject: "",
+    body: "",
+  },
+  notification: {
+    actionType: "notification",
+    userIds: [],
+    message: "",
+  },
+  javascript_transform: {
+    actionType: "javascript_transform",
+    code: "",
+  },
+  webhook_response: {
+    actionType: "webhook_response",
+    statusCode: 200,
+  },
+}
+
+/**
+ * Structurally valid minimal config for a newly created action node.
+ * Falls back to `{ actionType }` for unknown types.
+ */
+export function defaultActionConfig(actionType: string): Record<string, unknown> {
+  const defaults = defaultConfigMap[actionType]
+  return defaults ? { ...defaults } : { actionType }
+}

--- a/src/lib/execution/actions/webhook-response.ts
+++ b/src/lib/execution/actions/webhook-response.ts
@@ -79,13 +79,37 @@ export function hasWebhookResponseNode(nodes: unknown[]): boolean {
  * Sends a custom HTTP response back to the inbound webhook caller
  * via the in-memory Promise coordination mechanism.
  */
+/**
+ * Normalize the configured body into a plain object.
+ * The editor stores the body as a parsed JSON object, but older saved
+ * workflows may contain a raw JSON string — parse it defensively so
+ * interpolateDeep never iterates a string's characters.
+ */
+function normalizeBody(body: unknown): Record<string, unknown> {
+  if (typeof body === "string") {
+    try {
+      const parsed: unknown = JSON.parse(body)
+      if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>
+      }
+    } catch {
+      // Unparseable string: fall back to empty body
+    }
+    return {}
+  }
+  if (body !== null && typeof body === "object" && !Array.isArray(body)) {
+    return body as Record<string, unknown>
+  }
+  return {}
+}
+
 async function webhookResponseHandler(
   config: Record<string, unknown>,
   context: ExecutionContext,
   runId: string
 ): Promise<{ output: Record<string, unknown> }> {
   const statusCode = (config.statusCode as number) ?? 200
-  const rawBody = (config.body as Record<string, unknown>) ?? {}
+  const rawBody = normalizeBody(config.body)
 
   // Interpolate template variables in the body
   const interpolatedBody = interpolateDeep(rawBody, context)

--- a/src/lib/execution/condition-evaluator.test.ts
+++ b/src/lib/execution/condition-evaluator.test.ts
@@ -27,6 +27,18 @@ describe("resolveFieldPath", () => {
     expect(resolveFieldPath(ctx, "trigger.data.nonexistent.field")).toBeUndefined()
   })
 
+  it("returns undefined for undefined/null/empty/non-string path without throwing", () => {
+    const ctx = makeCtx({ deal: { value: 5000 } })
+    expect(() => resolveFieldPath(ctx, undefined)).not.toThrow()
+    expect(resolveFieldPath(ctx, undefined)).toBeUndefined()
+    expect(resolveFieldPath(ctx, null)).toBeUndefined()
+    expect(resolveFieldPath(ctx, "")).toBeUndefined()
+    expect(resolveFieldPath(ctx, "   ")).toBeUndefined()
+    expect(
+      resolveFieldPath(ctx, 42 as unknown as string)
+    ).toBeUndefined()
+  })
+
   it("resolves node output paths", () => {
     const ctx: ExecutionContext = {
       trigger: { type: "manual", data: {} },
@@ -228,6 +240,39 @@ describe("evaluateCondition", () => {
     // First group fails (500 not > 10000 AND stage != won), second passes (priority=high)
     // Top-level OR => true
     expect(evaluateCondition({ groups, logicOperator: "or" }, ctx)).toBe(true)
+  })
+
+  it("unconfigured condition (missing fieldPath) does not throw and evaluates sanely", () => {
+    const ctx = makeCtx({ deal: { value: 5000 } })
+    const groups: ConditionGroup[] = [
+      {
+        operator: "and",
+        conditions: [
+          {
+            fieldPath: undefined as unknown as string,
+            operator: "equals",
+            value: "won",
+          },
+        ],
+      },
+    ]
+    expect(() =>
+      evaluateCondition({ groups, logicOperator: "and" }, ctx)
+    ).not.toThrow()
+    expect(evaluateCondition({ groups, logicOperator: "and" }, ctx)).toBe(
+      false
+    )
+  })
+
+  it("unconfigured condition with is_empty evaluates to true", () => {
+    const ctx = makeCtx()
+    const groups: ConditionGroup[] = [
+      {
+        operator: "and",
+        conditions: [{ fieldPath: "", operator: "is_empty", value: null }],
+      },
+    ]
+    expect(evaluateCondition({ groups, logicOperator: "and" }, ctx)).toBe(true)
   })
 
   it("all groups fail with top-level OR returns false", () => {

--- a/src/lib/execution/condition-evaluator.ts
+++ b/src/lib/execution/condition-evaluator.ts
@@ -7,11 +7,19 @@ import type {
 /**
  * Walk a dot-notation path against the execution context.
  * e.g. "trigger.data.deal.value" -> ctx.trigger.data.deal.value
+ *
+ * A missing/empty/non-string path (e.g. a condition the user added but never
+ * configured) resolves to undefined instead of throwing, so the run does not
+ * hard-crash — the condition then evaluates like any other missing field
+ * (is_empty -> true, comparisons -> false).
  */
 export function resolveFieldPath(
   context: ExecutionContext,
-  path: string
+  path: string | null | undefined
 ): unknown {
+  if (typeof path !== "string" || path.trim() === "") {
+    return undefined
+  }
   const parts = path.split(".")
   let current: unknown = context
   for (const part of parts) {

--- a/src/lib/execution/engine.test.ts
+++ b/src/lib/execution/engine.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import type { ExecutionContext, WorkflowNode, ConditionNode, DelayNode } from "./types"
+import type { ExecutionContext, WorkflowNode, ConditionNode, DelayNode, SplitNode } from "./types"
 
 // Mock the DB module
 const mockDb = {
@@ -87,6 +87,23 @@ function makeConditionNode(
     config: { groups: [], logicOperator: "and" as const },
     trueBranch,
     falseBranch,
+    nextNodeId,
+  }
+}
+
+function makeSplitNode(
+  id: string,
+  branchA: string | null,
+  branchB: string | null,
+  nextNodeId: string | null
+): SplitNode {
+  return {
+    id,
+    type: "split",
+    label: `Split ${id}`,
+    config: {},
+    branchA,
+    branchB,
     nextNodeId,
   }
 }
@@ -417,5 +434,289 @@ describe("executeRun", () => {
     // Run should be completed
     const completionUpdate = updatedRuns.find(u => u.status === "completed")
     expect(completionUpdate).toBeDefined()
+  })
+
+  it("completes on resume when delay is the LAST node (no restart loop)", async () => {
+    const futureDate = new Date(Date.now() + 60 * 60 * 1000)
+    const nodes: WorkflowNode[] = [
+      makeActionNode("n1", "delay-1"),
+      makeDelayNode("delay-1", null), // delay is the terminal node
+    ]
+    const workflow = { id: "wf-8", nodes }
+    const run = {
+      id: "run-8",
+      workflowId: "wf-8",
+      status: "running",
+      context: null as ExecutionContext | null,
+      currentNodeId: null as string | null,
+      triggerData: { trigger_type: "manual", data: {} },
+    }
+
+    setupDbMocks(workflow, run)
+    mockResolveDelay.mockReturnValue(futureDate)
+
+    const { executeRun } = await import("./engine")
+    await executeRun("run-8")
+
+    const waitingUpdate = updatedRuns.find(u => u.status === "waiting")
+    expect(waitingUpdate).toBeDefined()
+    // Resume frame persisted inside context even though nextNodeId is null
+    const persistedContext = waitingUpdate!.context as ExecutionContext
+
+    // --- Resume: simulate the processor re-invoking the run ---
+    setupDbMocks(workflow, {
+      ...run,
+      context: persistedContext,
+      currentNodeId: (waitingUpdate!.currentNodeId as string | null) ?? null,
+    })
+
+    await executeRun("run-8")
+
+    // Nothing should be re-executed (old bug: fell back to node 0 and
+    // re-ran the whole workflow, then re-waited, forever)
+    expect(insertedSteps).toHaveLength(0)
+    const completionUpdate = updatedRuns.find(u => u.status === "completed")
+    expect(completionUpdate).toBeDefined()
+  })
+
+  it("resumes a delay inside a condition branch, finishes the branch, then runs the merge node", async () => {
+    const futureDate = new Date(Date.now() + 60 * 60 * 1000)
+    const nodes: WorkflowNode[] = [
+      makeConditionNode("cond-1", "b1", null, "merge-1"),
+      makeActionNode("b1", "d1"),
+      makeDelayNode("d1", "b2"),
+      makeActionNode("b2", null),
+      makeActionNode("merge-1", null),
+    ]
+    const workflow = { id: "wf-9", nodes }
+    const run = {
+      id: "run-9",
+      workflowId: "wf-9",
+      status: "running",
+      context: null as ExecutionContext | null,
+      currentNodeId: null as string | null,
+      triggerData: { trigger_type: "manual", data: {} },
+    }
+
+    setupDbMocks(workflow, run)
+    mockEvaluateCondition.mockReturnValue(true)
+    mockResolveDelay.mockReturnValue(futureDate)
+
+    const { executeRun } = await import("./engine")
+    await executeRun("run-9")
+
+    // First pass: cond-1, b1, then delay yields
+    expect(insertedSteps.map(s => s.nodeId)).toEqual(["cond-1", "b1", "d1"])
+    const waitingUpdate = updatedRuns.find(u => u.status === "waiting")
+    expect(waitingUpdate).toBeDefined()
+    const persistedContext = waitingUpdate!.context as ExecutionContext
+
+    // --- Resume ---
+    setupDbMocks(workflow, {
+      ...run,
+      context: persistedContext,
+      currentNodeId: (waitingUpdate!.currentNodeId as string | null) ?? null,
+    })
+
+    await executeRun("run-9")
+
+    // Old bug: only b2 ran, run was completed WITHOUT the merge node
+    expect(insertedSteps.map(s => s.nodeId)).toEqual(["b2", "merge-1"])
+    expect(updatedRuns.find(u => u.status === "completed")).toBeDefined()
+  })
+
+  it("resumes a delay in split branch A, then still runs branch B and the merge node", async () => {
+    const futureDate = new Date(Date.now() + 60 * 60 * 1000)
+    const nodes: WorkflowNode[] = [
+      makeSplitNode("split-1", "a1", "b1", "merge-1"),
+      makeDelayNode("a1", null), // delay is all of branch A
+      makeActionNode("b1", null),
+      makeActionNode("merge-1", null),
+    ]
+    const workflow = { id: "wf-10", nodes }
+    const run = {
+      id: "run-10",
+      workflowId: "wf-10",
+      status: "running",
+      context: null as ExecutionContext | null,
+      currentNodeId: null as string | null,
+      triggerData: { trigger_type: "manual", data: {} },
+    }
+
+    setupDbMocks(workflow, run)
+    mockResolveDelay.mockReturnValue(futureDate)
+
+    const { executeRun } = await import("./engine")
+    await executeRun("run-10")
+
+    expect(insertedSteps.map(s => s.nodeId)).toEqual(["split-1", "a1"])
+    const waitingUpdate = updatedRuns.find(u => u.status === "waiting")
+    expect(waitingUpdate).toBeDefined()
+    const persistedContext = waitingUpdate!.context as ExecutionContext
+
+    // --- Resume ---
+    setupDbMocks(workflow, {
+      ...run,
+      context: persistedContext,
+      currentNodeId: (waitingUpdate!.currentNodeId as string | null) ?? null,
+    })
+
+    await executeRun("run-10")
+
+    // Old bug: engine returned after branch A's delay and branch B never ran
+    expect(insertedSteps.map(s => s.nodeId)).toEqual(["b1", "merge-1"])
+    expect(updatedRuns.find(u => u.status === "completed")).toBeDefined()
+  })
+
+  it("runs a shared merge node exactly once when a condition branch points at it", async () => {
+    const nodes: WorkflowNode[] = [
+      makeConditionNode("cond-1", "t1", null, "merge-1"),
+      makeActionNode("t1", "merge-1"), // branch tail points at the merge node
+      makeActionNode("merge-1", null),
+    ]
+    const workflow = { id: "wf-11", nodes }
+    const run = {
+      id: "run-11",
+      workflowId: "wf-11",
+      status: "running",
+      context: null as ExecutionContext | null,
+      currentNodeId: null as string | null,
+      triggerData: { trigger_type: "manual", data: {} },
+    }
+
+    setupDbMocks(workflow, run)
+    mockEvaluateCondition.mockReturnValue(true)
+
+    const { executeRun } = await import("./engine")
+    await executeRun("run-11")
+
+    const stepNodeIds = insertedSteps.map(s => s.nodeId)
+    expect(stepNodeIds).toEqual(["cond-1", "t1", "merge-1"])
+    // Old bug: branch walked the merge chain AND the main loop ran it again
+    expect(stepNodeIds.filter(id => id === "merge-1")).toHaveLength(1)
+    expect(updatedRuns.find(u => u.status === "completed")).toBeDefined()
+  })
+
+  it("runs a shared merge node exactly once when both split branches point at it", async () => {
+    const nodes: WorkflowNode[] = [
+      makeSplitNode("split-1", "a1", "b1", "merge-1"),
+      makeActionNode("a1", "merge-1"),
+      makeActionNode("b1", "merge-1"),
+      makeActionNode("merge-1", null),
+    ]
+    const workflow = { id: "wf-12", nodes }
+    const run = {
+      id: "run-12",
+      workflowId: "wf-12",
+      status: "running",
+      context: null as ExecutionContext | null,
+      currentNodeId: null as string | null,
+      triggerData: { trigger_type: "manual", data: {} },
+    }
+
+    setupDbMocks(workflow, run)
+
+    const { executeRun } = await import("./engine")
+    await executeRun("run-12")
+
+    const stepNodeIds = insertedSteps.map(s => s.nodeId)
+    expect(stepNodeIds).toEqual(["split-1", "a1", "b1", "merge-1"])
+    expect(stepNodeIds.filter(id => id === "merge-1")).toHaveLength(1)
+    expect(updatedRuns.find(u => u.status === "completed")).toBeDefined()
+  })
+
+  it("detects a cycle and fails the run cleanly instead of looping forever", async () => {
+    const nodes: WorkflowNode[] = [
+      makeActionNode("n1", "n2"),
+      makeActionNode("n2", "n1"), // backward edge -> infinite loop
+    ]
+    const workflow = { id: "wf-13", nodes }
+    const run = {
+      id: "run-13",
+      workflowId: "wf-13",
+      status: "running",
+      context: null as ExecutionContext | null,
+      currentNodeId: null as string | null,
+      triggerData: { trigger_type: "manual", data: {} },
+    }
+
+    setupDbMocks(workflow, run)
+
+    const { executeRun } = await import("./engine")
+    await executeRun("run-13")
+
+    const failUpdate = updatedRuns.find(u => u.status === "failed")
+    expect(failUpdate).toBeDefined()
+    expect(failUpdate!.error).toMatch(/cycle/i)
+    // Step insertion is bounded by the cap
+    expect(insertedSteps.length).toBeLessThanOrEqual(1000)
+    expect(updatedRuns.find(u => u.status === "completed")).toBeUndefined()
+  })
+
+  it("fails the run with the BRANCH node's id when a node inside a branch throws", async () => {
+    const nodes: WorkflowNode[] = [
+      makeConditionNode("cond-1", "bad-1", null, "merge-1"),
+      makeActionNode("bad-1", null),
+      makeActionNode("merge-1", null),
+    ]
+    const workflow = { id: "wf-14", nodes }
+    const run = {
+      id: "run-14",
+      workflowId: "wf-14",
+      status: "running",
+      context: null as ExecutionContext | null,
+      currentNodeId: null as string | null,
+      triggerData: { trigger_type: "manual", data: {} },
+    }
+
+    setupDbMocks(workflow, run)
+    mockEvaluateCondition.mockReturnValue(true)
+
+    const { executeAction } = await import("./actions")
+    vi.mocked(executeAction).mockRejectedValueOnce(new Error("SMTP exploded"))
+
+    const { executeRun } = await import("./engine")
+    await executeRun("run-14")
+
+    const failUpdate = updatedRuns.find(u => u.status === "failed")
+    expect(failUpdate).toBeDefined()
+    // Old bug: the error was attributed to cond-1 (whose completed step got
+    // re-marked failed) instead of the actual failing branch node
+    expect(failUpdate!.error).toContain("bad-1")
+    expect(failUpdate!.error).toContain("SMTP exploded")
+    expect(failUpdate!.currentNodeId).toBe("bad-1")
+    // The merge node must not run after a branch failure
+    expect(insertedSteps.map(s => s.nodeId)).not.toContain("merge-1")
+  })
+
+  it("fails with a clear error for a nested condition inside a branch (v1 limitation)", async () => {
+    const nodes: WorkflowNode[] = [
+      makeConditionNode("cond-1", "nested-1", null, "merge-1"),
+      makeConditionNode("nested-1", "t1", null, null),
+      makeActionNode("t1", null),
+      makeActionNode("merge-1", null),
+    ]
+    const workflow = { id: "wf-15", nodes }
+    const run = {
+      id: "run-15",
+      workflowId: "wf-15",
+      status: "running",
+      context: null as ExecutionContext | null,
+      currentNodeId: null as string | null,
+      triggerData: { trigger_type: "manual", data: {} },
+    }
+
+    setupDbMocks(workflow, run)
+    mockEvaluateCondition.mockReturnValue(true)
+
+    const { executeRun } = await import("./engine")
+    await executeRun("run-15")
+
+    const failUpdate = updatedRuns.find(u => u.status === "failed")
+    expect(failUpdate).toBeDefined()
+    // Old bug: read config.actionType off the condition node and failed with
+    // a misleading "No handler registered" error
+    expect(failUpdate!.error).toContain("Nested condition nodes inside a condition/split branch are not supported")
+    expect(failUpdate!.currentNodeId).toBe("nested-1")
   })
 })

--- a/src/lib/execution/engine.ts
+++ b/src/lib/execution/engine.ts
@@ -49,11 +49,28 @@ type ResumableContext = ExecutionContext & { _resume?: ResumeState }
  */
 const MAX_STEPS_PER_RUN = 1000
 
-const CYCLE_ERROR = `Run exceeded the maximum of ${MAX_STEPS_PER_RUN} steps; the workflow graph likely contains a cycle`
+/**
+ * Wall-clock cap per engine invocation. The step cap alone bounds a cyclic
+ * graph, but with slow per-step DB work 1000 steps can still stall the inline
+ * processor for many minutes. This deadline fails a runaway run within ~1
+ * minute regardless of per-step cost. A legitimate acyclic workflow traverses
+ * far fewer nodes than this in far less time; delays re-enter with a fresh
+ * clock, so long waits don't count against it.
+ */
+const MAX_RUN_MS = 60_000
 
-/** Mutable step counter shared between the main loop and branch walks. */
+const CYCLE_ERROR = `Run exceeded the maximum of ${MAX_STEPS_PER_RUN} steps; the workflow graph likely contains a cycle`
+const TIMEOUT_ERROR = `Run exceeded the ${MAX_RUN_MS / 1000}s execution budget; the workflow graph likely contains a cycle`
+
+/** Mutable step counter + deadline shared between the main loop and branch walks. */
 interface StepGuard {
   steps: number
+  deadline: number
+}
+
+/** True once this invocation has run past its wall-clock budget. */
+function overBudget(guard: StepGuard): boolean {
+  return Date.now() > guard.deadline
 }
 
 type BranchOutcome = "ok" | "waiting" | "failed"
@@ -134,7 +151,7 @@ async function executeRunGraph(
   const resume = context._resume
   delete context._resume
 
-  const guard: StepGuard = { steps: 0 }
+  const guard: StepGuard = { steps: 0, deadline: Date.now() + MAX_RUN_MS }
 
   // Determine start position.
   let currentNodeId: string | null
@@ -189,6 +206,10 @@ async function executeRunGraph(
 
     if (++guard.steps > MAX_STEPS_PER_RUN) {
       await failRun(runId, CYCLE_ERROR, currentNodeId)
+      return
+    }
+    if (overBudget(guard)) {
+      await failRun(runId, TIMEOUT_ERROR, currentNodeId)
       return
     }
 
@@ -397,6 +418,10 @@ async function executeBranch(
 
     if (++guard.steps > MAX_STEPS_PER_RUN) {
       await failRun(runId, CYCLE_ERROR, currentNodeId)
+      return "failed"
+    }
+    if (overBudget(guard)) {
+      await failRun(runId, TIMEOUT_ERROR, currentNodeId)
       return "failed"
     }
 

--- a/src/lib/execution/engine.ts
+++ b/src/lib/execution/engine.ts
@@ -12,13 +12,60 @@ import type {
 } from "./types"
 
 /**
+ * Resume frame persisted inside the run's context JSON when a delay yields.
+ *
+ * Control flow has stack-like state (in-progress condition/split branch,
+ * pending split branch B, merge point) that the run's single `currentNodeId`
+ * column cannot represent. Without this frame:
+ * - a delay as the LAST node persisted currentNodeId = null and the resume
+ *   fell back to node 0, re-executing the whole workflow forever;
+ * - a delay inside a branch lost the merge point (run "completed" without
+ *   ever running the merge chain);
+ * - a delay in split branch A lost pending branch B entirely.
+ *
+ * On resume the engine reads this frame (and removes it from the context) to
+ * rebuild the exact walk position. Nesting is bounded because nested
+ * condition/split nodes inside a branch are rejected (v1 limitation), so a
+ * single frame is sufficient -- no full stack needed.
+ */
+interface ResumeState {
+  /** Node to resume at. Null means the current segment is already finished. */
+  nodeId: string | null
+  /** True when nodeId lives inside a condition/split branch (walked by executeBranch). */
+  inBranch?: boolean
+  /** Split branch B start node still pending (delay was hit inside branch A). */
+  pendingBranch?: string | null
+  /** Main-loop merge node to continue at once all branch segments finish. */
+  mergeNodeId?: string | null
+}
+
+type ResumableContext = ExecutionContext & { _resume?: ResumeState }
+
+/**
+ * Hard cap on steps executed per engine invocation. A backward nextNodeId
+ * would otherwise loop forever, inserting a step row per iteration and --
+ * because the processor awaits executeRun inline -- freezing ALL workflow
+ * processing server-wide. When exceeded the run is failed cleanly.
+ */
+const MAX_STEPS_PER_RUN = 1000
+
+const CYCLE_ERROR = `Run exceeded the maximum of ${MAX_STEPS_PER_RUN} steps; the workflow graph likely contains a cycle`
+
+/** Mutable step counter shared between the main loop and branch walks. */
+interface StepGuard {
+  steps: number
+}
+
+type BranchOutcome = "ok" | "waiting" | "failed"
+
+/**
  * Execute a workflow run by walking its node graph.
  *
  * Loads the run and its workflow from DB, builds a node map, then walks
- * nodes sequentially. Handles action (stub), condition (branch), and delay
- * (yield to DB) node types.
+ * nodes sequentially. Handles action, condition (branch), split (two
+ * branches), and delay (yield to DB) node types.
  *
- * On delay: persists context and resume point, sets run to "waiting", returns.
+ * On delay: persists context + resume frame, sets run to "waiting", returns.
  * On error: fails the step and run with a descriptive message.
  * On completion: sets run to "completed".
  */
@@ -67,8 +114,8 @@ async function executeRunGraph(
   }
 
   // Initialize or restore execution context
-  const savedContext = run.context as unknown as ExecutionContext | null
-  let context: ExecutionContext = savedContext?.trigger && savedContext?.nodes
+  const savedContext = run.context as unknown as ResumableContext | null
+  const context: ResumableContext = savedContext?.trigger && savedContext?.nodes
     ? savedContext
     : {
         trigger: {
@@ -81,14 +128,67 @@ async function executeRunGraph(
   // Set workflow creator userId for CRM action mutations
   context._workflowUserId = workflow.createdBy
 
-  // Determine start node: resume from currentNodeId or start from first node
-  let currentNodeId: string | null = run.currentNodeId ?? nodeList[0].id
+  // Pull the resume frame (if any) out of the context. Only the delay yield
+  // paths write it back; every other persist stores the context without it,
+  // so a completed/failed run never carries a stale frame.
+  const resume = context._resume
+  delete context._resume
+
+  const guard: StepGuard = { steps: 0 }
+
+  // Determine start position.
+  let currentNodeId: string | null
+
+  if (resume) {
+    if (resume.inBranch) {
+      // Delay was hit inside a condition/split branch. Finish the branch
+      // segment first, then any pending split branch, then fall through to
+      // the merge node in the main loop.
+      const mergeNodeId = resume.mergeNodeId ?? null
+      const segment = await executeBranch(
+        resume.nodeId,
+        nodeMap,
+        context,
+        runId,
+        { pendingBranch: resume.pendingBranch ?? null, mergeNodeId },
+        guard
+      )
+      if (segment !== "ok") return
+
+      if (resume.pendingBranch) {
+        const pending = await executeBranch(
+          resume.pendingBranch,
+          nodeMap,
+          context,
+          runId,
+          { pendingBranch: null, mergeNodeId },
+          guard
+        )
+        if (pending !== "ok") return
+      }
+
+      currentNodeId = mergeNodeId
+    } else {
+      // Top-level delay. nodeId may legitimately be null (delay was the last
+      // node) -- the main loop is skipped and the run completes below instead
+      // of falling back to node 0 and re-executing the whole workflow.
+      currentNodeId = resume.nodeId
+    }
+  } else {
+    // Fresh run (or legacy waiting run persisted before resume frames existed).
+    currentNodeId = run.currentNodeId ?? nodeList[0].id
+  }
 
   // Walk the node graph
   while (currentNodeId) {
     const node = nodeMap.get(currentNodeId)
     if (!node) {
       await failRun(runId, `Node '${currentNodeId}' not found in workflow graph`, currentNodeId)
+      return
+    }
+
+    if (++guard.steps > MAX_STEPS_PER_RUN) {
+      await failRun(runId, CYCLE_ERROR, currentNodeId)
       return
     }
 
@@ -128,13 +228,21 @@ async function executeRunGraph(
           await completeStep(step.id, branchOutput)
           await persistContext(runId, context)
 
-          // Execute the matching branch
+          // Execute the matching branch. The branch stops at the merge node
+          // (node.nextNodeId), which the main loop runs exactly once below.
           const branchStartId = matched ? node.trueBranch : node.falseBranch
-          const delayHit = await executeBranch(branchStartId, nodeMap, context, runId)
-          if (delayHit) {
-            // A delay was hit inside the branch -- run is now waiting
-            return
-          }
+          const outcome = await executeBranch(
+            branchStartId,
+            nodeMap,
+            context,
+            runId,
+            { pendingBranch: null, mergeNodeId: node.nextNodeId },
+            guard
+          )
+          // "waiting": run yielded on a delay. "failed": the branch already
+          // failed its own step + the run -- do NOT fall into the catch below,
+          // which would corrupt this condition's already-completed step.
+          if (outcome !== "ok") return
 
           // Continue from merge point
           nextNodeId = node.nextNodeId
@@ -147,11 +255,28 @@ async function executeRunGraph(
           await completeStep(step.id, output)
           await persistContext(runId, context)
 
-          // Execute both branches sequentially (true parallelism is out of scope)
-          const delayA = await executeBranch(node.branchA, nodeMap, context, runId)
-          if (delayA) return
-          const delayB = await executeBranch(node.branchB, nodeMap, context, runId)
-          if (delayB) return
+          // Execute both branches sequentially (true parallelism is out of
+          // scope). While branch A runs, branch B is carried as the pending
+          // branch so a delay inside A can persist it in the resume frame.
+          const outcomeA = await executeBranch(
+            node.branchA,
+            nodeMap,
+            context,
+            runId,
+            { pendingBranch: node.branchB, mergeNodeId: node.nextNodeId },
+            guard
+          )
+          if (outcomeA !== "ok") return
+
+          const outcomeB = await executeBranch(
+            node.branchB,
+            nodeMap,
+            context,
+            runId,
+            { pendingBranch: null, mergeNodeId: node.nextNodeId },
+            guard
+          )
+          if (outcomeB !== "ok") return
 
           nextNodeId = node.nextNodeId // merge point
           break
@@ -181,6 +306,10 @@ async function executeRunGraph(
               })
               .where(eq(workflowRunSteps.id, step.id))
 
+            // Persist the resume frame. nodeId may be null when the delay is
+            // the last node -- on resume the run then completes instead of
+            // restarting from node 0.
+            context._resume = { nodeId: node.nextNodeId }
             await db
               .update(workflowRuns)
               .set({
@@ -235,76 +364,127 @@ async function executeRunGraph(
 }
 
 /**
- * Execute a branch (true or false path from a condition node).
- * Walks nodes linearly until nextNodeId is null.
- * Returns true if a delay was hit (run is now waiting).
+ * Execute a branch (a condition's true/false path or a split's branch A/B).
+ * Walks nodes linearly until nextNodeId is null or the merge node is reached.
+ *
+ * The merge node (continuation.mergeNodeId, i.e. the parent node's nextNodeId)
+ * belongs to the MAIN loop: stopping there prevents a shared merge chain from
+ * executing once per branch plus once in the main loop.
+ *
+ * Errors are handled per-node HERE (not in the main loop's catch): the failing
+ * branch node's own step is marked failed and failRun records that node's id.
+ * Bubbling instead would re-mark the parent condition/split step -- already
+ * completed -- as failed and attribute the failure to the wrong node.
+ *
+ * Returns "ok" when the branch finished, "waiting" when a delay yielded
+ * (resume frame persisted), "failed" when a node failed (run already failed).
  */
 async function executeBranch(
   startNodeId: string | null,
   nodeMap: Map<string, WorkflowNode>,
-  context: ExecutionContext,
-  runId: string
-): Promise<boolean> {
-  if (!startNodeId) return false
+  context: ResumableContext,
+  runId: string,
+  continuation: { pendingBranch: string | null; mergeNodeId: string | null },
+  guard: StepGuard
+): Promise<BranchOutcome> {
+  if (!startNodeId) return "ok"
 
   let currentNodeId: string | null = startNodeId
 
-  while (currentNodeId) {
+  while (currentNodeId && currentNodeId !== continuation.mergeNodeId) {
     const node = nodeMap.get(currentNodeId)
     if (!node) break
 
-    const [step] = await db
-      .insert(workflowRunSteps)
-      .values({
-        runId,
-        nodeId: node.id,
-        status: "running",
-        input: { context: context } as Record<string, unknown>,
-        startedAt: new Date(),
-      })
-      .returning()
+    if (++guard.steps > MAX_STEPS_PER_RUN) {
+      await failRun(runId, CYCLE_ERROR, currentNodeId)
+      return "failed"
+    }
 
-    if (node.type === "delay") {
-      const resumeAt = resolveDelay(node.config, context)
+    let step: { id: string } | undefined
+    try {
+      ;[step] = await db
+        .insert(workflowRunSteps)
+        .values({
+          runId,
+          nodeId: node.id,
+          status: "running",
+          input: { context: context } as Record<string, unknown>,
+          startedAt: new Date(),
+        })
+        .returning()
 
-      if (resumeAt === null) {
-        const output = { delayed: false, skipped: true }
-        context.nodes[node.id] = { output, status: "completed" }
-        await completeStep(step.id, output)
-        await persistContext(runId, context)
+      if (node.type === "delay") {
+        const resumeAt = resolveDelay(node.config, context)
+
+        if (resumeAt === null) {
+          const output = { delayed: false, skipped: true }
+          context.nodes[node.id] = { output, status: "completed" }
+          await completeStep(step.id, output)
+          await persistContext(runId, context)
+        } else {
+          const output = { delayed: true, resumeAt: resumeAt.toISOString() }
+          context.nodes[node.id] = { output, status: "completed" }
+
+          await db
+            .update(workflowRunSteps)
+            .set({ status: "waiting", resumeAt, output: output as Record<string, unknown> })
+            .where(eq(workflowRunSteps.id, step.id))
+
+          // Persist the full resume frame: where to continue inside this
+          // branch, which split branch is still pending, and the merge point.
+          context._resume = {
+            nodeId: node.nextNodeId,
+            inBranch: true,
+            pendingBranch: continuation.pendingBranch,
+            mergeNodeId: continuation.mergeNodeId,
+          }
+          await db
+            .update(workflowRuns)
+            .set({
+              status: "waiting",
+              currentNodeId: node.nextNodeId,
+              context: context as unknown as Record<string, unknown>,
+            })
+            .where(eq(workflowRuns.id, runId))
+
+          return "waiting" // Delay hit
+        }
+      } else if (node.type === "condition" || node.type === "split") {
+        // v1 limitation: the resume frame is a single level deep, so nested
+        // control flow inside a branch cannot be resumed correctly. Fail with
+        // a clear message instead of misreading the node as an action.
+        throw new Error(
+          `Nested ${node.type} nodes inside a condition/split branch are not supported`
+        )
       } else {
-        const output = { delayed: true, resumeAt: resumeAt.toISOString() }
-        context.nodes[node.id] = { output, status: "completed" }
-
+        // Action node
+        const actionType = node.config.actionType as string
+        const result = await executeAction(actionType, node.config, context, runId)
+        context.nodes[node.id] = { output: result.output, status: "completed" }
+        await completeStep(step.id, result.output)
+        await persistContext(runId, context)
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      const errorOutput = (error as Error & { output?: Record<string, unknown> }).output
+      if (step) {
         await db
           .update(workflowRunSteps)
-          .set({ status: "waiting", resumeAt, output: output as Record<string, unknown> })
-          .where(eq(workflowRunSteps.id, step.id))
-
-        await db
-          .update(workflowRuns)
           .set({
-            status: "waiting",
-            currentNodeId: node.nextNodeId,
-            context: context as unknown as Record<string, unknown>,
+            status: "failed",
+            output: errorOutput ?? ({ error: message } as Record<string, unknown>),
+            completedAt: new Date(),
           })
-          .where(eq(workflowRuns.id, runId))
-
-        return true // Delay hit
+          .where(eq(workflowRunSteps.id, step.id))
       }
-    } else {
-      // Action node (no nested conditions in v1)
-      const actionType = (node.config as Record<string, unknown>).actionType as string
-      const result = await executeAction(actionType, node.config as Record<string, unknown>, context, runId)
-      context.nodes[node.id] = { output: result.output, status: "completed" }
-      await completeStep(step.id, result.output)
-      await persistContext(runId, context)
+      await failRun(runId, `Node '${node.id}' (${node.label}) failed: ${message}`, node.id)
+      return "failed"
     }
 
     currentNodeId = node.nextNodeId
   }
 
-  return false
+  return "ok"
 }
 
 async function completeStep(stepId: string, output: Record<string, unknown>): Promise<void> {

--- a/src/lib/execution/execution-processor.test.ts
+++ b/src/lib/execution/execution-processor.test.ts
@@ -124,5 +124,65 @@ describe("execution-processor", () => {
       expect(count).toBe(0)
       expect(mockExecuteRun).not.toHaveBeenCalled()
     })
+
+    it("resets started_at when resuming so the run is not instantly reclaimed as stale", async () => {
+      const pastDate = new Date(Date.now() - 60000)
+      mockDb.execute.mockResolvedValueOnce([
+        { id: "step-1", run_id: "run-1", resume_at: pastDate },
+      ])
+
+      const setCalls: Record<string, unknown>[] = []
+      const updateChain = {
+        set: vi.fn().mockImplementation((vals: Record<string, unknown>) => {
+          setCalls.push(vals)
+          return updateChain
+        }),
+        where: vi.fn().mockResolvedValue(undefined),
+      }
+      mockDb.update.mockReturnValue(updateChain)
+
+      const { processWaitingRuns } = await import("./execution-processor")
+      await processWaitingRuns()
+
+      // The run's transition back to 'running' must refresh the lease:
+      // started_at still holds the pre-delay claim time, and the stale-run
+      // reclaim would otherwise fail the run the moment it resumes.
+      const runUpdate = setCalls.find(v => v.status === "running")
+      expect(runUpdate).toBeDefined()
+      expect(runUpdate!.startedAt).toBeInstanceOf(Date)
+    })
+  })
+
+  describe("reclaimStaleRuns", () => {
+    it("reclaims runs stuck in 'running' past the lease and fails them", async () => {
+      mockDb.execute
+        .mockResolvedValueOnce([]) // orphaned step cleanup
+        .mockResolvedValueOnce([{ id: "run-stale" }]) // reclaimed runs
+
+      const { reclaimStaleRuns } = await import("./execution-processor")
+      const count = await reclaimStaleRuns()
+
+      expect(count).toBe(1)
+      expect(mockDb.execute).toHaveBeenCalledTimes(2)
+
+      // The reclaim statement must fail (not re-run) stale 'running' runs so
+      // side effects are not duplicated, and must gate on started_at age.
+      const reclaimSql = (mockDb.execute.mock.calls[1][0] as { strings: TemplateStringsArray }).strings.join("?")
+      expect(reclaimSql).toContain("SET status = 'failed'")
+      expect(reclaimSql).toContain("status = 'running'")
+      expect(reclaimSql).toContain("started_at < NOW()")
+    })
+
+    it("returns 0 and touches nothing when no runs exceeded the lease", async () => {
+      mockDb.execute
+        .mockResolvedValueOnce([]) // orphaned step cleanup
+        .mockResolvedValueOnce([]) // no stale runs
+
+      const { reclaimStaleRuns } = await import("./execution-processor")
+      const count = await reclaimStaleRuns()
+
+      expect(count).toBe(0)
+      expect(mockExecuteRun).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/lib/execution/execution-processor.ts
+++ b/src/lib/execution/execution-processor.ts
@@ -8,6 +8,16 @@ const INITIAL_DELAY = 5_000 // 5 seconds - let server finish booting
 const POLL_INTERVAL = 5_000 // 5 seconds - execution should be responsive
 
 /**
+ * Execution lease: a run claimed as 'running' executes inline within a single
+ * processor tick, so any run still 'running' after this long belongs to a
+ * process that crashed or restarted mid-run. 5 minutes is generous headroom
+ * over the longest legitimate run (actions are HTTP calls / DB writes that
+ * complete in seconds) while still unblocking a stuck workflow queue quickly.
+ * Keep in sync with the INTERVAL literal in reclaimStaleRuns.
+ */
+const STALE_RUN_TIMEOUT_MINUTES = 5
+
+/**
  * Self-scheduling execution processor loop.
  *
  * Polls DB for pending workflow runs, claims them atomically with serial
@@ -25,6 +35,10 @@ export function startExecutionProcessor(): void {
 function scheduleTick(delay: number): void {
   setTimeout(async () => {
     try {
+      // Reclaim runs stranded in 'running' (e.g. after a server restart)
+      // BEFORE claiming: serial enforcement skips any workflow that still has
+      // a 'running' run, so a stranded run would block its workflow forever.
+      await reclaimStaleRuns()
       const pendingCount = await processPendingRuns()
       const waitingCount = await processWaitingRuns()
       if (pendingCount > 0 || waitingCount > 0) {
@@ -39,6 +53,52 @@ function scheduleTick(delay: number): void {
     // Always schedule the next tick
     scheduleTick(POLL_INTERVAL)
   }, delay)
+}
+
+/**
+ * Reclaim runs stuck in 'running' longer than the execution lease
+ * (STALE_RUN_TIMEOUT_MINUTES, measured against started_at).
+ *
+ * A process crash/restart mid-run leaves the run 'running' forever; serial
+ * enforcement (NOT EXISTS status IN ('running','waiting')) then blocks every
+ * future pending run of that workflow. We mark such runs FAILED rather than
+ * re-queueing them: their side effects (emails, HTTP calls, CRM writes) may
+ * already have fired and we cannot know where execution stopped, so a re-run
+ * would duplicate them. Orphaned 'running' steps are failed as well so the
+ * run detail UI doesn't show a step spinning forever.
+ */
+export async function reclaimStaleRuns(): Promise<number> {
+  // Fail orphaned in-flight steps of stale runs first (while the parent runs
+  // are still identifiable by status = 'running').
+  await db.execute(sql`
+    UPDATE workflow_run_steps
+    SET status = 'failed',
+        completed_at = NOW(),
+        output = '{"error": "Abandoned: parent run reclaimed after exceeding its execution lease"}'::jsonb
+    WHERE status = 'running'
+      AND run_id IN (
+        SELECT id FROM workflow_runs
+        WHERE status = 'running'
+          AND started_at < NOW() - make_interval(mins => ${STALE_RUN_TIMEOUT_MINUTES})
+      )
+  `)
+
+  const staleError = `Run was stuck in running state past the ${STALE_RUN_TIMEOUT_MINUTES}-minute execution lease (server likely restarted mid-run); reclaimed to unblock the workflow queue`
+  const reclaimed = await db.execute(sql`
+    UPDATE workflow_runs
+    SET status = 'failed',
+        error = ${staleError},
+        completed_at = NOW()
+    WHERE status = 'running'
+      AND started_at < NOW() - make_interval(mins => ${STALE_RUN_TIMEOUT_MINUTES})
+    RETURNING id
+  `)
+
+  const count = (reclaimed as unknown as unknown[])?.length ?? 0
+  if (count > 0) {
+    console.log(`[execution-processor] Reclaimed ${count} stale running run(s)`)
+  }
+  return count
 }
 
 /**
@@ -124,10 +184,13 @@ export async function processWaitingRuns(): Promise<number> {
       .set({ status: "completed" as const, completedAt: new Date() })
       .where(eq(workflowRunSteps.id, stepId))
 
-    // Transition run back to running
+    // Transition run back to running. Reset started_at: it still holds the
+    // original claim time (pre-delay, possibly hours ago), and the stale-run
+    // reclaim measures the execution lease against started_at -- without the
+    // reset a legitimately resumed run would be reclaimed immediately.
     await db
       .update(workflowRuns)
-      .set({ status: "running" as const })
+      .set({ status: "running" as const, startedAt: new Date() })
       .where(eq(workflowRuns.id, runId))
 
     try {

--- a/src/lib/mutations/workflows.test.ts
+++ b/src/lib/mutations/workflows.test.ts
@@ -94,6 +94,157 @@ describe("createWorkflow", () => {
     expect(result.success).toBe(false)
     expect(result).toHaveProperty("error")
   })
+
+  it("rejects action node with structurally invalid config", async () => {
+    const result = await createWorkflow({
+      name: "Bad Workflow",
+      createdBy: "user-1",
+      nodes: [
+        {
+          id: "node-1",
+          type: "action",
+          label: "call api",
+          // No method/url keys at all — the old bare default shape
+          config: { actionType: "http_request" },
+          nextNodeId: null,
+        },
+      ],
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toContain("node-1")
+      expect(result.error).toContain("call api")
+    }
+    expect(mockDb.insert).not.toHaveBeenCalled()
+  })
+
+  it("rejects action node with unknown action type", async () => {
+    const result = await createWorkflow({
+      name: "Bad Workflow",
+      createdBy: "user-1",
+      nodes: [
+        {
+          id: "node-1",
+          type: "action",
+          label: "mystery",
+          config: { actionType: "does_not_exist" },
+          nextNodeId: null,
+        },
+      ],
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toContain("Unknown action type")
+    }
+  })
+
+  it("saves workflow with fully configured action node", async () => {
+    const nodes = [
+      {
+        id: "node-1",
+        type: "action",
+        label: "call api",
+        config: {
+          actionType: "http_request",
+          method: "POST",
+          url: "https://example.com/hook",
+          timeout: 30,
+          retryCount: 1,
+        },
+        nextNodeId: null,
+      },
+    ]
+    const mockWorkflow = { id: "wf-1", name: "Good Workflow", nodes }
+
+    mockDb.insert.mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([mockWorkflow]),
+      }),
+    })
+
+    const result = await createWorkflow({
+      name: "Good Workflow",
+      createdBy: "user-1",
+      nodes,
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it("saves unconfigured draft node with structurally valid empty defaults", async () => {
+    // Matches the default config createNewNode now produces: keys present,
+    // values safe-empty. Save must not be blocked for a brand-new node.
+    const nodes = [
+      {
+        id: "node-1",
+        type: "action",
+        label: "http request",
+        config: {
+          actionType: "http_request",
+          method: "GET",
+          url: "",
+          timeout: 30,
+          retryCount: 0,
+        },
+        nextNodeId: null,
+      },
+    ]
+    const mockWorkflow = { id: "wf-1", name: "Draft", nodes }
+
+    mockDb.insert.mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([mockWorkflow]),
+      }),
+    })
+
+    const result = await createWorkflow({
+      name: "Draft",
+      createdBy: "user-1",
+      nodes,
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it("ignores non-action node types during config validation", async () => {
+    const nodes = [
+      {
+        id: "node-1",
+        type: "condition",
+        label: "check",
+        config: { groups: [], logicOperator: "and" },
+        nextNodeId: null,
+        trueBranch: null,
+        falseBranch: null,
+      },
+      {
+        id: "node-2",
+        type: "split",
+        label: "Split",
+        config: {},
+        nextNodeId: null,
+        branchA: null,
+        branchB: null,
+      },
+    ]
+    const mockWorkflow = { id: "wf-1", name: "No Actions", nodes }
+
+    mockDb.insert.mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([mockWorkflow]),
+      }),
+    })
+
+    const result = await createWorkflow({
+      name: "No Actions",
+      createdBy: "user-1",
+      nodes,
+    })
+
+    expect(result.success).toBe(true)
+  })
 })
 
 describe("updateWorkflow", () => {
@@ -133,6 +284,159 @@ describe("updateWorkflow", () => {
 
     expect(result.success).toBe(false)
     expect(result).toHaveProperty("error")
+  })
+
+  it("rejects update with structurally invalid action node config", async () => {
+    mockDb.query.workflows.findFirst.mockResolvedValue({
+      id: "wf-1",
+      name: "Workflow",
+      triggers: [],
+      nodes: [],
+      active: false,
+      nextRunAt: null,
+    })
+
+    const result = await updateWorkflow("wf-1", {
+      nodes: [
+        {
+          id: "node-9",
+          type: "action",
+          label: "send mail",
+          // recipients has the wrong type entirely
+          config: { actionType: "email", recipients: "not-an-array" },
+          nextNodeId: null,
+        },
+      ],
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toContain("node-9")
+    }
+    expect(mockDb.update).not.toHaveBeenCalled()
+  })
+})
+
+describe("updateWorkflow nextRunAt scheduling", () => {
+  const intervalTrigger = {
+    type: "schedule",
+    mode: "interval",
+    intervalMinutes: 60,
+  }
+
+  function mockUpdateCapture() {
+    const setSpy = vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: "wf-1" }]),
+      }),
+    })
+    mockDb.update.mockReturnValue({ set: setSpy })
+    return setSpy
+  }
+
+  it("does not reset nextRunAt when triggers are sent but unchanged", async () => {
+    const existingNextRun = new Date(Date.now() + 5 * 60_000)
+    mockDb.query.workflows.findFirst.mockResolvedValue({
+      id: "wf-1",
+      name: "Scheduled",
+      triggers: [intervalTrigger],
+      nodes: [],
+      active: true,
+      nextRunAt: existingNextRun,
+    })
+    const setSpy = mockUpdateCapture()
+
+    // Editor-style save: same triggers, same active flag
+    const result = await updateWorkflow("wf-1", {
+      name: "Scheduled (renamed)",
+      triggers: [{ ...intervalTrigger }],
+      active: true,
+    })
+
+    expect(result.success).toBe(true)
+    const updates = setSpy.mock.calls[0][0]
+    expect(updates).not.toHaveProperty("nextRunAt")
+  })
+
+  it("seeds nextRunAt on activation", async () => {
+    mockDb.query.workflows.findFirst.mockResolvedValue({
+      id: "wf-1",
+      name: "Scheduled",
+      triggers: [intervalTrigger],
+      nodes: [],
+      active: false,
+      nextRunAt: null,
+    })
+    const setSpy = mockUpdateCapture()
+
+    const before = Date.now()
+    const result = await updateWorkflow("wf-1", { active: true })
+    const after = Date.now()
+
+    expect(result.success).toBe(true)
+    const updates = setSpy.mock.calls[0][0]
+    expect(updates.nextRunAt).toBeInstanceOf(Date)
+    expect(updates.nextRunAt.getTime()).toBeGreaterThanOrEqual(before + 60 * 60_000)
+    expect(updates.nextRunAt.getTime()).toBeLessThanOrEqual(after + 60 * 60_000)
+  })
+
+  it("clears nextRunAt on deactivation", async () => {
+    mockDb.query.workflows.findFirst.mockResolvedValue({
+      id: "wf-1",
+      name: "Scheduled",
+      triggers: [intervalTrigger],
+      nodes: [],
+      active: true,
+      nextRunAt: new Date(),
+    })
+    const setSpy = mockUpdateCapture()
+
+    const result = await updateWorkflow("wf-1", { active: false })
+
+    expect(result.success).toBe(true)
+    const updates = setSpy.mock.calls[0][0]
+    expect(updates).toHaveProperty("nextRunAt", null)
+  })
+
+  it("recomputes nextRunAt when the schedule config actually changes", async () => {
+    mockDb.query.workflows.findFirst.mockResolvedValue({
+      id: "wf-1",
+      name: "Scheduled",
+      triggers: [intervalTrigger],
+      nodes: [],
+      active: true,
+      nextRunAt: new Date(Date.now() + 55 * 60_000),
+    })
+    const setSpy = mockUpdateCapture()
+
+    const result = await updateWorkflow("wf-1", {
+      triggers: [{ type: "schedule", mode: "interval", intervalMinutes: 5 }],
+      active: true,
+    })
+
+    expect(result.success).toBe(true)
+    const updates = setSpy.mock.calls[0][0]
+    expect(updates.nextRunAt).toBeInstanceOf(Date)
+    // Recomputed from the new 5-minute interval, not the old 60
+    expect(updates.nextRunAt.getTime()).toBeLessThanOrEqual(Date.now() + 6 * 60_000)
+  })
+
+  it("backfills nextRunAt for an active scheduled workflow missing it", async () => {
+    mockDb.query.workflows.findFirst.mockResolvedValue({
+      id: "wf-1",
+      name: "Scheduled",
+      triggers: [intervalTrigger],
+      nodes: [],
+      active: true,
+      nextRunAt: null,
+    })
+    const setSpy = mockUpdateCapture()
+
+    const result = await updateWorkflow("wf-1", { name: "Renamed" })
+
+    expect(result.success).toBe(true)
+    const updates = setSpy.mock.calls[0][0]
+    expect(updates.nextRunAt).toBeInstanceOf(Date)
   })
 })
 

--- a/src/lib/mutations/workflows.ts
+++ b/src/lib/mutations/workflows.ts
@@ -5,7 +5,8 @@ import { z } from "zod"
 import type { Workflow } from "@/db/schema/workflows"
 import { generateWebhookSecret } from "@/lib/triggers/webhook-secret"
 import { computeNextRun, getScheduleTrigger } from "@/lib/triggers/schedule-utils"
-import type { TriggerConfig } from "@/lib/triggers/types"
+import type { TriggerConfig, ScheduleTriggerConfig } from "@/lib/triggers/types"
+import { validateActionConfigStructure } from "@/lib/execution/actions/types"
 
 // --- Schemas ---
 
@@ -39,6 +40,51 @@ type DeleteResult =
   | { success: true }
   | { success: false; error: string }
 
+// --- Node config validation ---
+
+/**
+ * Structurally validate every action node's config before persisting.
+ *
+ * Policy: action configs are validated on EVERY save (create and update),
+ * not just on activation — but only structurally (known actionType, required
+ * keys present, correct value types). Business completeness such as a
+ * non-empty URL is not enforced, so incomplete drafts with safe-empty
+ * defaults still save. Non-action node types (condition/delay/split) are
+ * left alone here.
+ *
+ * Returns an error message naming the offending node, or null if all valid.
+ */
+function findInvalidActionNode(
+  nodes: Array<Record<string, unknown>>
+): string | null {
+  for (const node of nodes) {
+    if (node.type !== "action") continue
+
+    const config = (node.config ?? {}) as Record<string, unknown>
+    const result = validateActionConfigStructure(config)
+    if (!result.success) {
+      const label =
+        typeof node.label === "string" && node.label.length > 0
+          ? node.label
+          : null
+      const id = typeof node.id === "string" ? node.id : "unknown"
+      const nodeName = label ? `"${label}" (${id})` : id
+      return `Invalid config for action node ${nodeName}: ${result.error}`
+    }
+  }
+  return null
+}
+
+/**
+ * Normalized identity of a schedule trigger's effective config, used to
+ * detect whether the schedule actually changed between saves (key-order and
+ * unrelated-trigger changes must not reset the clock).
+ */
+function scheduleKey(schedule: ScheduleTriggerConfig | null): string {
+  if (!schedule) return ""
+  return `${schedule.mode}|${schedule.intervalMinutes ?? ""}|${schedule.cronExpression ?? ""}`
+}
+
 // --- Mutations ---
 
 export async function createWorkflow(
@@ -50,6 +96,11 @@ export async function createWorkflow(
   }
 
   const { name, description, triggers, nodes, createdBy } = parsed.data
+
+  const nodeError = findInvalidActionNode(nodes)
+  if (nodeError) {
+    return { success: false, error: nodeError }
+  }
 
   const [workflow] = await db
     .insert(workflows)
@@ -94,13 +145,36 @@ export async function updateWorkflow(
   if (data.nodes !== undefined) updates.nodes = data.nodes
   if (data.active !== undefined) updates.active = data.active
 
+  if (data.nodes !== undefined) {
+    const nodeError = findInvalidActionNode(data.nodes)
+    if (nodeError) {
+      return { success: false, error: nodeError }
+    }
+  }
+
   // The schedule processor only claims workflows with nextRunAt <= now, and
-  // nothing else seeds that column — (re)compute it whenever triggers or
-  // active state change, so schedule triggers actually fire.
-  if (data.triggers !== undefined || data.active !== undefined) {
-    const effectiveTriggers = (data.triggers ?? existing.triggers ?? []) as TriggerConfig[]
-    const effectiveActive = data.active ?? existing.active
-    const schedule = getScheduleTrigger(effectiveTriggers)
+  // nothing else seeds that column — nextRunAt is (re)computed here so
+  // schedule triggers actually fire. However, the editor sends `triggers`
+  // on every save, so recomputing unconditionally would reset an interval
+  // schedule's clock on each save (a workflow edited more often than its
+  // interval would never fire). Only recompute when:
+  //   - the active flag actually flips (activation seeds, deactivation
+  //     clears), or
+  //   - the schedule trigger's config actually changed, or
+  //   - an active scheduled workflow is missing nextRunAt (backfill).
+  const effectiveTriggers = (data.triggers ?? existing.triggers ?? []) as TriggerConfig[]
+  const effectiveActive = data.active ?? existing.active
+  const schedule = getScheduleTrigger(effectiveTriggers)
+
+  const activeChanged = data.active !== undefined && data.active !== existing.active
+  const existingSchedule = getScheduleTrigger((existing.triggers ?? []) as TriggerConfig[])
+  const scheduleChanged =
+    data.triggers !== undefined &&
+    scheduleKey(schedule?.trigger ?? null) !== scheduleKey(existingSchedule?.trigger ?? null)
+  const needsBackfill =
+    effectiveActive && schedule !== null && existing.nextRunAt == null
+
+  if (activeChanged || scheduleChanged || needsBackfill) {
     updates.nextRunAt =
       effectiveActive && schedule ? computeNextRun(schedule.trigger) : null
   }

--- a/src/lib/templates/http-templates.ts
+++ b/src/lib/templates/http-templates.ts
@@ -2,7 +2,8 @@ export interface HttpTemplateConfig {
   method: string
   url: string
   headers: Record<string, string>
-  body: string
+  /** Omitted for GET/HEAD templates — those requests must not carry a body */
+  body?: string
   timeout: number
   retryCount: number
 }
@@ -84,7 +85,6 @@ export const builtInHttpTemplates: HttpTemplate[] = [
       method: "GET",
       url: "https://api.tally.so/forms/{{FORM_ID}}/responses",
       headers: { Authorization: "Bearer {{API_KEY}}" },
-      body: "",
       timeout: 30,
       retryCount: 0,
     },
@@ -98,7 +98,6 @@ export const builtInHttpTemplates: HttpTemplate[] = [
       method: "GET",
       url: "https://api.typeform.com/forms/{{FORM_ID}}/responses",
       headers: { Authorization: "Bearer {{API_TOKEN}}" },
-      body: "",
       timeout: 30,
       retryCount: 0,
     },

--- a/src/lib/triggers/create-run.ts
+++ b/src/lib/triggers/create-run.ts
@@ -1,3 +1,4 @@
+import { and, eq } from "drizzle-orm"
 import { db } from "@/db"
 import { workflowRuns } from "@/db/schema/workflows"
 import type { WorkflowRun } from "@/db/schema/workflows"
@@ -45,4 +46,28 @@ export async function createWorkflowRun(
     .returning()
 
   return run
+}
+
+/**
+ * Atomically claim a pending workflow run for in-process (synchronous) execution.
+ *
+ * The execution processor polls for runs with status "pending" and claims them
+ * with `UPDATE ... WHERE status = 'pending'`. A caller that wants to execute a
+ * run itself (e.g. the inbound webhook route waiting on a webhook_response node)
+ * MUST claim the run through this helper first, using the exact same status
+ * protocol: flip "pending" -> "running" atomically. Whichever side wins the
+ * UPDATE owns the run; the other side sees zero affected rows and backs off.
+ *
+ * Returns true if this caller claimed the run (and may execute it), false if
+ * the run was not claimable (already claimed by the processor, or created in a
+ * non-pending state such as the recursion-limit "failed" short-circuit).
+ */
+export async function claimWorkflowRun(runId: string): Promise<boolean> {
+  const claimed = await db
+    .update(workflowRuns)
+    .set({ status: "running", startedAt: new Date() })
+    .where(and(eq(workflowRuns.id, runId), eq(workflowRuns.status, "pending")))
+    .returning({ id: workflowRuns.id })
+
+  return claimed.length > 0
 }

--- a/src/lib/triggers/manual-trigger.ts
+++ b/src/lib/triggers/manual-trigger.ts
@@ -14,11 +14,13 @@ interface TriggerManualRunParams {
 
 type TriggerManualRunResult =
   | { success: true; runId: string }
-  | { success: false; error: string }
+  | { success: false; error: string; code?: "workflow_inactive" }
 
 /**
  * Trigger a manual workflow run.
  * Creates a workflow run with trigger_type "manual" and optional entity data.
+ * Inactive workflows are rejected, matching every other trigger path
+ * (webhook 404s inactive, schedule and CRM matcher only consider active).
  */
 export async function triggerManualRun(
   params: TriggerManualRunParams
@@ -31,6 +33,14 @@ export async function triggerManualRun(
 
   if (!workflow) {
     return { success: false, error: "Workflow not found" }
+  }
+
+  if (!workflow.active) {
+    return {
+      success: false,
+      error: "Workflow is not active",
+      code: "workflow_inactive",
+    }
   }
 
   const envelope: TriggerEnvelope = {

--- a/src/lib/triggers/matcher.test.ts
+++ b/src/lib/triggers/matcher.test.ts
@@ -157,6 +157,23 @@ describe("matchesTrigger", () => {
     expect(matchesTrigger(trigger, "deal.stage_changed", payload)).toBe(true)
   })
 
+  it("ignores residual stage filters when action is not stage_changed", () => {
+    // A leftover fromStageId/toStageId on an "updated" trigger must not
+    // silently prevent it from ever matching.
+    const trigger: CrmEventTriggerConfig = {
+      ...baseTrigger,
+      action: "updated",
+      fromStageId: "stage-a",
+      toStageId: "stage-b",
+    }
+    const payload: CrmEventPayload = {
+      ...basePayload,
+      action: "updated",
+      changedFields: ["title"],
+    }
+    expect(matchesTrigger(trigger, "deal.updated", payload)).toBe(true)
+  })
+
   it("with both fromStageId and toStageId requires both to match", () => {
     const trigger: CrmEventTriggerConfig = {
       ...baseTrigger,
@@ -281,6 +298,78 @@ describe("matchAndFireTriggers", () => {
     expect(mockCreateWorkflowRun).toHaveBeenCalledTimes(2)
     expect(mockCreateWorkflowRun).toHaveBeenCalledWith("wf-a", expect.any(Object))
     expect(mockCreateWorkflowRun).toHaveBeenCalledWith("wf-b", expect.any(Object))
+  })
+
+  it("includes stage-change metadata (oldStageId, newStageId, changedFields, userId) in the envelope", async () => {
+    mockWorkflowQuery([
+      {
+        id: "wf-stage",
+        active: true,
+        triggers: [
+          {
+            type: "crm_event",
+            entity: "deal",
+            action: "stage_changed",
+            fieldFilters: [],
+          },
+        ],
+      },
+    ])
+
+    const stagePayload: DealStageChangedPayload = {
+      entity: "deal",
+      entityId: "deal-1",
+      action: "updated",
+      data: { title: "Test Deal", stageId: "stage-b" },
+      changedFields: ["stageId"],
+      userId: "user-1",
+      timestamp: "2026-03-28T00:00:00Z",
+      oldStageId: "stage-a",
+      newStageId: "stage-b",
+    }
+
+    await matchAndFireTriggers("deal.stage_changed", stagePayload)
+
+    expect(mockCreateWorkflowRun).toHaveBeenCalledWith(
+      "wf-stage",
+      expect.objectContaining({
+        data: expect.objectContaining({
+          title: "Test Deal",
+          entityId: "deal-1",
+          oldStageId: "stage-a",
+          newStageId: "stage-b",
+          changedFields: ["stageId"],
+          userId: "user-1",
+        }),
+      })
+    )
+  })
+
+  it("does not let record fields clobber envelope metadata", async () => {
+    mockWorkflowQuery([
+      {
+        id: "wf-1",
+        active: true,
+        triggers: [{ type: "crm_event", entity: "deal", action: "created", fieldFilters: [] }],
+      },
+    ])
+
+    await matchAndFireTriggers("deal.created", {
+      ...eventPayload,
+      data: { title: "Evil", entityId: "spoofed", action: "deleted" },
+    })
+
+    expect(mockCreateWorkflowRun).toHaveBeenCalledWith(
+      "wf-1",
+      expect.objectContaining({
+        data: expect.objectContaining({
+          entityId: "deal-1",
+          action: "created",
+          entity: "deal",
+          title: "Evil",
+        }),
+      })
+    )
   })
 
   it("does not throw when createWorkflowRun fails for one workflow", async () => {

--- a/src/lib/triggers/matcher.ts
+++ b/src/lib/triggers/matcher.ts
@@ -32,15 +32,19 @@ export function matchesTrigger(
     if (!hasOverlap) return false
   }
 
-  // Stage filter checks (deal.stage_changed)
-  if (trigger.fromStageId) {
-    const stagePayload = payload as DealStageChangedPayload
-    if (stagePayload.oldStageId !== trigger.fromStageId) return false
-  }
+  // Stage filter checks apply only to stage_changed triggers. A residual
+  // from/to stage filter left on e.g. an "updated" trigger must not silently
+  // prevent it from ever matching.
+  if (trigger.action === "stage_changed") {
+    if (trigger.fromStageId) {
+      const stagePayload = payload as DealStageChangedPayload
+      if (stagePayload.oldStageId !== trigger.fromStageId) return false
+    }
 
-  if (trigger.toStageId) {
-    const stagePayload = payload as DealStageChangedPayload
-    if (stagePayload.newStageId !== trigger.toStageId) return false
+    if (trigger.toStageId) {
+      const stagePayload = payload as DealStageChangedPayload
+      if (stagePayload.newStageId !== trigger.toStageId) return false
+    }
   }
 
   return true
@@ -70,15 +74,29 @@ export async function matchAndFireTriggers(
 
       if (!matchesTrigger(trigger, eventName, payload)) continue
 
+      // Entity record fields are spread first; event metadata is written
+      // after the spread so it can never be clobbered by record fields.
+      // Stage-change metadata (oldStageId/newStageId) lives at the top level
+      // of the payload, not in payload.data, so it must be copied explicitly
+      // for stage_changed workflows to reference from/to stages.
+      const stagePayload = payload as Partial<DealStageChangedPayload>
       const envelope: TriggerEnvelope = {
         trigger_type: "crm_event",
         trigger_id: `${eventName}-${Date.now()}`,
         timestamp: payload.timestamp,
         data: {
+          ...payload.data,
           entity: payload.entity,
           entityId: payload.entityId,
           action: payload.action,
-          ...payload.data,
+          changedFields: payload.changedFields,
+          userId: payload.userId,
+          ...(stagePayload.oldStageId !== undefined
+            ? { oldStageId: stagePayload.oldStageId }
+            : {}),
+          ...(stagePayload.newStageId !== undefined
+            ? { newStageId: stagePayload.newStageId }
+            : {}),
         },
       }
 

--- a/src/lib/triggers/schedule-processor.test.ts
+++ b/src/lib/triggers/schedule-processor.test.ts
@@ -4,6 +4,7 @@ import type { TriggerConfig } from "./types"
 // Mock db module
 vi.mock("@/db", () => {
   const mockDb = {
+    select: vi.fn(),
     update: vi.fn(),
   }
   return { db: mockDb }
@@ -26,6 +27,7 @@ import { computeNextRun, getScheduleTrigger } from "./schedule-utils"
 import { processScheduledWorkflows, startScheduleProcessor } from "./schedule-processor"
 
 const mockDb = db as unknown as {
+  select: ReturnType<typeof vi.fn>
   update: ReturnType<typeof vi.fn>
 }
 const mockCreateWorkflowRun = createWorkflowRun as ReturnType<typeof vi.fn>
@@ -35,14 +37,28 @@ const mockGetScheduleTrigger = getScheduleTrigger as ReturnType<typeof vi.fn>
 beforeEach(() => {
   vi.clearAllMocks()
   vi.useFakeTimers()
+  // Slightly after the scheduledAt used across tests, so recomputed next runs
+  // (e.g. 12:10, 12:30) are in the future and re-anchoring does not kick in
+  // unless a test explicitly moves the clock.
+  vi.setSystemTime(new Date("2026-03-28T12:00:05Z"))
 })
 
-// Helper to set up the mock db.update chain for claiming workflows
+// Helper to set up the pre-claim select of due workflows (id + nextRunAt)
+function setupDueSelect(rows: Array<{ id: string; nextRunAt: Date | null }>) {
+  const whereFn = vi.fn().mockResolvedValue(rows)
+  const fromFn = vi.fn().mockReturnValue({ where: whereFn })
+  mockDb.select.mockReturnValue({ from: fromFn })
+  return { fromFn, whereFn }
+}
+
+// Helper to set up the mock db.update chain for claiming workflows.
+// NOTE: UPDATE...RETURNING yields post-update rows, so claimed rows have
+// nextRunAt already nulled -- the processor must NOT read scheduledAt from them.
 function setupClaimQuery(claimedWorkflows: Array<{
   id: string
   name: string
   triggers: TriggerConfig[]
-  nextRunAt: Date
+  nextRunAt: Date | null
   active: boolean
 }>) {
   const returningFn = vi.fn().mockResolvedValue(claimedWorkflows)
@@ -52,15 +68,9 @@ function setupClaimQuery(claimedWorkflows: Array<{
   return { setFn, whereFn, returningFn }
 }
 
-// Helper to set up update for nextRunAt (second call to db.update)
-function setupNextRunAtUpdate() {
-  const whereFn2 = vi.fn().mockResolvedValue(undefined)
-  const setFn2 = vi.fn().mockReturnValue({ where: whereFn2 })
-  return { setFn2, whereFn2 }
-}
-
 describe("processScheduledWorkflows", () => {
   it("finds workflows where nextRunAt <= now and active = true via atomic UPDATE...RETURNING", async () => {
+    setupDueSelect([])
     const { setFn } = setupClaimQuery([])
 
     await processScheduledWorkflows()
@@ -76,10 +86,12 @@ describe("processScheduledWorkflows", () => {
       { type: "schedule", mode: "interval", intervalMinutes: 30 },
     ]
 
-    // First call: claim query returns one workflow
-    // Second call: update nextRunAt
+    setupDueSelect([{ id: "wf-1", nextRunAt: scheduledAt }])
+
+    // First update call: claim query returns one workflow (nextRunAt nulled)
+    // Second update call: update nextRunAt
     const claimReturning = vi.fn().mockResolvedValue([
-      { id: "wf-1", name: "Test", triggers, nextRunAt: scheduledAt, active: true },
+      { id: "wf-1", name: "Test", triggers, nextRunAt: null, active: true },
     ])
     const claimWhere = vi.fn().mockReturnValue({ returning: claimReturning })
     const claimSet = vi.fn().mockReturnValue({ where: claimWhere })
@@ -109,6 +121,112 @@ describe("processScheduledWorkflows", () => {
     })
   })
 
+  it("uses the pre-claim scheduled time for the envelope even though RETURNING rows have nextRunAt null", async () => {
+    const scheduledAt = new Date("2026-03-28T11:59:30Z")
+    const triggers: TriggerConfig[] = [
+      { type: "schedule", mode: "interval", intervalMinutes: 30 },
+    ]
+
+    setupDueSelect([{ id: "wf-1", nextRunAt: scheduledAt }])
+
+    const claimReturning = vi.fn().mockResolvedValue([
+      // Post-update row: nextRunAt already nulled by the claim
+      { id: "wf-1", name: "Test", triggers, nextRunAt: null, active: true },
+    ])
+    const claimWhere = vi.fn().mockReturnValue({ returning: claimReturning })
+    const claimSet = vi.fn().mockReturnValue({ where: claimWhere })
+
+    const updateWhere = vi.fn().mockResolvedValue(undefined)
+    const updateSet = vi.fn().mockReturnValue({ where: updateWhere })
+
+    mockDb.update
+      .mockReturnValueOnce({ set: claimSet })
+      .mockReturnValueOnce({ set: updateSet })
+
+    mockGetScheduleTrigger.mockReturnValue({ trigger: triggers[0], index: 0 })
+    mockComputeNextRun.mockReturnValue(new Date("2026-03-28T12:29:30Z"))
+    mockCreateWorkflowRun.mockResolvedValue({ id: "run-1", status: "pending" })
+
+    await processScheduledWorkflows()
+
+    expect(mockCreateWorkflowRun).toHaveBeenCalledWith(
+      "wf-1",
+      expect.objectContaining({
+        data: { scheduledAt: scheduledAt.toISOString() },
+      })
+    )
+  })
+
+  it("computes the next run from the scheduled time (not processing time) to avoid interval drift", async () => {
+    const scheduledAt = new Date("2026-03-28T12:00:00Z")
+    const triggers: TriggerConfig[] = [
+      { type: "schedule", mode: "interval", intervalMinutes: 30 },
+    ]
+
+    setupDueSelect([{ id: "wf-1", nextRunAt: scheduledAt }])
+
+    const claimReturning = vi.fn().mockResolvedValue([
+      { id: "wf-1", name: "Test", triggers, nextRunAt: null, active: true },
+    ])
+    const claimWhere = vi.fn().mockReturnValue({ returning: claimReturning })
+    const claimSet = vi.fn().mockReturnValue({ where: claimWhere })
+
+    const updateWhere = vi.fn().mockResolvedValue(undefined)
+    const updateSet = vi.fn().mockReturnValue({ where: updateWhere })
+
+    mockDb.update
+      .mockReturnValueOnce({ set: claimSet })
+      .mockReturnValueOnce({ set: updateSet })
+
+    mockGetScheduleTrigger.mockReturnValue({ trigger: triggers[0], index: 0 })
+    const nextRun = new Date("2026-03-28T12:30:00Z")
+    mockComputeNextRun.mockReturnValue(nextRun)
+    mockCreateWorkflowRun.mockResolvedValue({ id: "run-1", status: "pending" })
+
+    await processScheduledWorkflows()
+
+    // Base for computeNextRun must be the scheduled time, not "now"
+    expect(mockComputeNextRun).toHaveBeenCalledWith(triggers[0], scheduledAt)
+    expect(updateSet).toHaveBeenCalledWith({ nextRunAt: nextRun })
+  })
+
+  it("re-anchors from now when the recomputed next run is already in the past (downtime catch-up)", async () => {
+    vi.setSystemTime(new Date("2026-03-28T15:00:00Z"))
+    const scheduledAt = new Date("2026-03-28T12:00:00Z") // 3h behind
+    const triggers: TriggerConfig[] = [
+      { type: "schedule", mode: "interval", intervalMinutes: 30 },
+    ]
+
+    setupDueSelect([{ id: "wf-1", nextRunAt: scheduledAt }])
+
+    const claimReturning = vi.fn().mockResolvedValue([
+      { id: "wf-1", name: "Test", triggers, nextRunAt: null, active: true },
+    ])
+    const claimWhere = vi.fn().mockReturnValue({ returning: claimReturning })
+    const claimSet = vi.fn().mockReturnValue({ where: claimWhere })
+
+    const updateWhere = vi.fn().mockResolvedValue(undefined)
+    const updateSet = vi.fn().mockReturnValue({ where: updateWhere })
+
+    mockDb.update
+      .mockReturnValueOnce({ set: claimSet })
+      .mockReturnValueOnce({ set: updateSet })
+
+    mockGetScheduleTrigger.mockReturnValue({ trigger: triggers[0], index: 0 })
+    const pastNext = new Date("2026-03-28T12:30:00Z")
+    const futureNext = new Date("2026-03-28T15:30:00Z")
+    mockComputeNextRun
+      .mockReturnValueOnce(pastNext) // anchored to scheduledAt -> in the past
+      .mockReturnValueOnce(futureNext) // re-anchored from now
+    mockCreateWorkflowRun.mockResolvedValue({ id: "run-1", status: "pending" })
+
+    await processScheduledWorkflows()
+
+    expect(mockComputeNextRun).toHaveBeenNthCalledWith(1, triggers[0], scheduledAt)
+    expect(mockComputeNextRun).toHaveBeenNthCalledWith(2, triggers[0])
+    expect(updateSet).toHaveBeenCalledWith({ nextRunAt: futureNext })
+  })
+
   it("ALWAYS creates a run even when previous run is active (queuing, never skipping)", async () => {
     // The processor does NOT check for existing active runs.
     // It unconditionally creates a "pending" run, which is the queuing mechanism.
@@ -117,8 +235,10 @@ describe("processScheduledWorkflows", () => {
       { type: "schedule", mode: "interval", intervalMinutes: 5 },
     ]
 
+    setupDueSelect([{ id: "wf-1", nextRunAt: scheduledAt }])
+
     const claimReturning = vi.fn().mockResolvedValue([
-      { id: "wf-1", name: "Test", triggers, nextRunAt: scheduledAt, active: true },
+      { id: "wf-1", name: "Test", triggers, nextRunAt: null, active: true },
     ])
     const claimWhere = vi.fn().mockReturnValue({ returning: claimReturning })
     const claimSet = vi.fn().mockReturnValue({ where: claimWhere })
@@ -151,8 +271,10 @@ describe("processScheduledWorkflows", () => {
       { type: "schedule", mode: "cron", cronExpression: "0 * * * *" },
     ]
 
+    setupDueSelect([{ id: "wf-1", nextRunAt: scheduledAt }])
+
     const claimReturning = vi.fn().mockResolvedValue([
-      { id: "wf-1", name: "Test", triggers, nextRunAt: scheduledAt, active: true },
+      { id: "wf-1", name: "Test", triggers, nextRunAt: null, active: true },
     ])
     const claimWhere = vi.fn().mockReturnValue({ returning: claimReturning })
     const claimSet = vi.fn().mockReturnValue({ where: claimWhere })
@@ -179,6 +301,7 @@ describe("processScheduledWorkflows", () => {
   })
 
   it("returns count of processed workflows", async () => {
+    setupDueSelect([])
     setupClaimQuery([])
 
     const count = await processScheduledWorkflows()
@@ -191,9 +314,14 @@ describe("processScheduledWorkflows", () => {
       { type: "schedule", mode: "interval", intervalMinutes: 10 },
     ]
 
+    setupDueSelect([
+      { id: "wf-1", nextRunAt: scheduledAt },
+      { id: "wf-2", nextRunAt: scheduledAt },
+    ])
+
     const claimReturning = vi.fn().mockResolvedValue([
-      { id: "wf-1", name: "Test1", triggers, nextRunAt: scheduledAt, active: true },
-      { id: "wf-2", name: "Test2", triggers, nextRunAt: scheduledAt, active: true },
+      { id: "wf-1", name: "Test1", triggers, nextRunAt: null, active: true },
+      { id: "wf-2", name: "Test2", triggers, nextRunAt: null, active: true },
     ])
     const claimWhere = vi.fn().mockReturnValue({ returning: claimReturning })
     const claimSet = vi.fn().mockReturnValue({ where: claimWhere })
@@ -218,6 +346,130 @@ describe("processScheduledWorkflows", () => {
 
     expect(count).toBe(2)
     expect(mockCreateWorkflowRun).toHaveBeenCalledTimes(2)
+  })
+
+  it("isolates run-creation failures: one failing workflow does not abort the rest of the batch", async () => {
+    const scheduledAt = new Date("2026-03-28T12:00:00Z")
+    const triggers: TriggerConfig[] = [
+      { type: "schedule", mode: "interval", intervalMinutes: 10 },
+    ]
+
+    setupDueSelect([
+      { id: "wf-fail", nextRunAt: scheduledAt },
+      { id: "wf-ok", nextRunAt: scheduledAt },
+    ])
+
+    const claimReturning = vi.fn().mockResolvedValue([
+      { id: "wf-fail", name: "Fail", triggers, nextRunAt: null, active: true },
+      { id: "wf-ok", name: "Ok", triggers, nextRunAt: null, active: true },
+    ])
+    const claimWhere = vi.fn().mockReturnValue({ returning: claimReturning })
+    const claimSet = vi.fn().mockReturnValue({ where: claimWhere })
+
+    const updateWhere = vi.fn().mockResolvedValue(undefined)
+    const updateSet = vi.fn().mockReturnValue({ where: updateWhere })
+
+    mockDb.update
+      .mockReturnValueOnce({ set: claimSet })
+      .mockReturnValue({ set: updateSet })
+
+    mockGetScheduleTrigger.mockReturnValue({ trigger: triggers[0], index: 0 })
+    mockComputeNextRun.mockReturnValue(new Date("2026-03-28T12:10:00Z"))
+    mockCreateWorkflowRun
+      .mockRejectedValueOnce(new Error("DB error"))
+      .mockResolvedValueOnce({ id: "run-2", status: "pending" })
+
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    await expect(processScheduledWorkflows()).resolves.toBe(2)
+
+    // Both workflows attempted despite the first one throwing
+    expect(mockCreateWorkflowRun).toHaveBeenCalledTimes(2)
+    expect(mockCreateWorkflowRun).toHaveBeenCalledWith("wf-ok", expect.any(Object))
+    expect(consoleError).toHaveBeenCalled()
+
+    // Neither workflow is left with nextRunAt = null: two nextRunAt updates
+    expect(updateSet).toHaveBeenCalledTimes(2)
+
+    consoleError.mockRestore()
+  })
+
+  it("restores the original scheduled time when run creation fails, so it retries next cycle", async () => {
+    const scheduledAt = new Date("2026-03-28T12:00:00Z")
+    const triggers: TriggerConfig[] = [
+      { type: "schedule", mode: "interval", intervalMinutes: 10 },
+    ]
+
+    setupDueSelect([{ id: "wf-fail", nextRunAt: scheduledAt }])
+
+    const claimReturning = vi.fn().mockResolvedValue([
+      { id: "wf-fail", name: "Fail", triggers, nextRunAt: null, active: true },
+    ])
+    const claimWhere = vi.fn().mockReturnValue({ returning: claimReturning })
+    const claimSet = vi.fn().mockReturnValue({ where: claimWhere })
+
+    const updateWhere = vi.fn().mockResolvedValue(undefined)
+    const updateSet = vi.fn().mockReturnValue({ where: updateWhere })
+
+    mockDb.update
+      .mockReturnValueOnce({ set: claimSet })
+      .mockReturnValueOnce({ set: updateSet })
+
+    mockGetScheduleTrigger.mockReturnValue({ trigger: triggers[0], index: 0 })
+    mockCreateWorkflowRun.mockRejectedValueOnce(new Error("DB error"))
+
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    await processScheduledWorkflows()
+
+    // nextRunAt restored to the original scheduled time (not recomputed forward)
+    expect(updateSet).toHaveBeenCalledWith({ nextRunAt: scheduledAt })
+    // No forward recomputation on the failure path
+    expect(mockComputeNextRun).not.toHaveBeenCalled()
+
+    consoleError.mockRestore()
+  })
+
+  it("does not abort the batch when the nextRunAt update itself fails", async () => {
+    const scheduledAt = new Date("2026-03-28T12:00:00Z")
+    const triggers: TriggerConfig[] = [
+      { type: "schedule", mode: "interval", intervalMinutes: 10 },
+    ]
+
+    setupDueSelect([
+      { id: "wf-1", nextRunAt: scheduledAt },
+      { id: "wf-2", nextRunAt: scheduledAt },
+    ])
+
+    const claimReturning = vi.fn().mockResolvedValue([
+      { id: "wf-1", name: "One", triggers, nextRunAt: null, active: true },
+      { id: "wf-2", name: "Two", triggers, nextRunAt: null, active: true },
+    ])
+    const claimWhere = vi.fn().mockReturnValue({ returning: claimReturning })
+    const claimSet = vi.fn().mockReturnValue({ where: claimWhere })
+
+    const failingWhere = vi.fn().mockRejectedValue(new Error("update failed"))
+    const failingSet = vi.fn().mockReturnValue({ where: failingWhere })
+    const okWhere = vi.fn().mockResolvedValue(undefined)
+    const okSet = vi.fn().mockReturnValue({ where: okWhere })
+
+    mockDb.update
+      .mockReturnValueOnce({ set: claimSet })
+      .mockReturnValueOnce({ set: failingSet })
+      .mockReturnValueOnce({ set: okSet })
+
+    mockGetScheduleTrigger.mockReturnValue({ trigger: triggers[0], index: 0 })
+    mockComputeNextRun.mockReturnValue(new Date("2026-03-28T12:10:00Z"))
+    mockCreateWorkflowRun.mockResolvedValue({ id: "run-1", status: "pending" })
+
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    await expect(processScheduledWorkflows()).resolves.toBe(2)
+
+    expect(mockCreateWorkflowRun).toHaveBeenCalledTimes(2)
+    expect(okSet).toHaveBeenCalledWith({ nextRunAt: new Date("2026-03-28T12:10:00Z") })
+
+    consoleError.mockRestore()
   })
 })
 

--- a/src/lib/triggers/schedule-processor.ts
+++ b/src/lib/triggers/schedule-processor.ts
@@ -46,6 +46,21 @@ function scheduleTick(delay: number): void {
  * The execution engine (Phase 26) picks up pending runs in order.
  */
 export async function processScheduledWorkflows(): Promise<number> {
+  const now = new Date()
+
+  // Capture scheduled times BEFORE the claim nulls them. UPDATE...RETURNING
+  // yields post-update rows, so nextRunAt would already be null there and the
+  // envelope's scheduledAt would silently fall back to claim time.
+  const due = await db
+    .select({ id: workflows.id, nextRunAt: workflows.nextRunAt })
+    .from(workflows)
+    .where(and(eq(workflows.active, true), lte(workflows.nextRunAt, now)))
+
+  const scheduledAtById = new Map<string, Date>()
+  for (const row of due) {
+    if (row.nextRunAt) scheduledAtById.set(row.id, row.nextRunAt)
+  }
+
   // Atomic claim: set nextRunAt to null for all due workflows, returning claimed rows
   const claimed = await db
     .update(workflows)
@@ -53,7 +68,7 @@ export async function processScheduledWorkflows(): Promise<number> {
     .where(
       and(
         eq(workflows.active, true),
-        lte(workflows.nextRunAt, new Date())
+        lte(workflows.nextRunAt, now)
       )
     )
     .returning()
@@ -61,25 +76,58 @@ export async function processScheduledWorkflows(): Promise<number> {
   for (const workflow of claimed) {
     const triggers = (workflow.triggers ?? []) as TriggerConfig[]
     const schedule = getScheduleTrigger(triggers)
+    const scheduledAt = scheduledAtById.get(workflow.id) ?? now
 
-    // Create a pending run unconditionally (queuing, never skipping)
-    await createWorkflowRun(workflow.id, {
-      trigger_type: "schedule",
-      trigger_id: schedule ? String(schedule.index) : "0",
-      timestamp: new Date().toISOString(),
-      data: {
-        scheduledAt: workflow.nextRunAt?.toISOString() ?? new Date().toISOString(),
-      },
-    })
+    // Create a pending run unconditionally (queuing, never skipping).
+    // Each workflow is isolated: one failure must never abort the rest of the
+    // batch or leave this workflow's nextRunAt null (silently dead).
+    let runCreated = false
+    try {
+      await createWorkflowRun(workflow.id, {
+        trigger_type: "schedule",
+        trigger_id: schedule ? String(schedule.index) : "0",
+        timestamp: new Date().toISOString(),
+        data: {
+          scheduledAt: scheduledAt.toISOString(),
+        },
+      })
+      runCreated = true
+    } catch (error) {
+      console.error(
+        `[schedule-processor] Failed to create run for workflow ${workflow.id}:`,
+        error
+      )
+    }
 
-    // Compute and store next run time
+    // Compute and store next run time -- always, even when run creation failed
     if (schedule) {
-      const nextRunAt = computeNextRun(schedule.trigger)
-      if (nextRunAt) {
-        await db
-          .update(workflows)
-          .set({ nextRunAt })
-          .where(eq(workflows.id, workflow.id))
+      try {
+        let nextRunAt: Date | null
+        if (runCreated) {
+          // Anchor the next occurrence to the scheduled time (not processing
+          // time) so interval schedules don't drift forward each fire.
+          nextRunAt = computeNextRun(schedule.trigger, scheduledAt)
+          if (nextRunAt && nextRunAt.getTime() <= Date.now()) {
+            // More than one period behind (e.g. downtime): re-anchor from now
+            // to avoid an immediate catch-up burst.
+            nextRunAt = computeNextRun(schedule.trigger)
+          }
+        } else {
+          // Run creation failed: restore the original scheduled time so the
+          // claim retries on the next poll cycle instead of dying.
+          nextRunAt = scheduledAt
+        }
+        if (nextRunAt) {
+          await db
+            .update(workflows)
+            .set({ nextRunAt })
+            .where(eq(workflows.id, workflow.id))
+        }
+      } catch (error) {
+        console.error(
+          `[schedule-processor] Failed to update nextRunAt for workflow ${workflow.id}:`,
+          error
+        )
       }
     }
   }

--- a/src/lib/triggers/schedule-utils.test.ts
+++ b/src/lib/triggers/schedule-utils.test.ts
@@ -60,6 +60,50 @@ describe("computeNextRun", () => {
     const result = computeNextRun(config)
     expect(result).toBeNull()
   })
+
+  it("with mode 'cron' defaults to UTC regardless of server timezone", () => {
+    // 12:00Z base; "0 10 * * *" in UTC has already passed today -> tomorrow 10:00Z
+    const config: ScheduleTriggerConfig = { type: "schedule", mode: "cron", cronExpression: "0 10 * * *" }
+    const result = computeNextRun(config)
+    expect(result).toEqual(new Date("2026-03-29T10:00:00Z"))
+  })
+
+  it("with mode 'cron' and a timezone evaluates the expression in that timezone", () => {
+    // Base 12:00Z = 09:00 in America/Sao_Paulo (UTC-3).
+    // "0 10 * * *" in Sao Paulo -> 10:00 local same day = 13:00Z.
+    const config = {
+      type: "schedule",
+      mode: "cron",
+      cronExpression: "0 10 * * *",
+      timezone: "America/Sao_Paulo",
+    } as ScheduleTriggerConfig
+    const result = computeNextRun(config)
+    expect(result).toEqual(new Date("2026-03-28T13:00:00Z"))
+  })
+
+  it("with mode 'cron' and an invalid timezone falls back to UTC instead of returning null", () => {
+    const config = {
+      type: "schedule",
+      mode: "cron",
+      cronExpression: "0 * * * *",
+      timezone: "Not/AZone",
+    } as ScheduleTriggerConfig
+    const result = computeNextRun(config)
+    expect(result).toEqual(new Date("2026-03-28T13:00:00Z"))
+  })
+
+  it("with mode 'cron' and a timezone respects a custom fromDate", () => {
+    // From 2026-03-28T00:30:00Z = 21:30 (Mar 27) in Sao Paulo.
+    // "0 22 * * *" local -> 22:00 Mar 27 local = 01:00Z Mar 28.
+    const config = {
+      type: "schedule",
+      mode: "cron",
+      cronExpression: "0 22 * * *",
+      timezone: "America/Sao_Paulo",
+    } as ScheduleTriggerConfig
+    const result = computeNextRun(config, new Date("2026-03-28T00:30:00Z"))
+    expect(result).toEqual(new Date("2026-03-28T01:00:00Z"))
+  })
 })
 
 describe("getScheduleTrigger", () => {

--- a/src/lib/triggers/schedule-utils.ts
+++ b/src/lib/triggers/schedule-utils.ts
@@ -5,7 +5,11 @@ import type { ScheduleTriggerConfig, TriggerConfig } from "./types"
  * Compute the next run time for a schedule trigger.
  *
  * - mode "interval": adds intervalMinutes to fromDate (defaults to now)
- * - mode "cron": parses cronExpression and returns next occurrence after fromDate
+ * - mode "cron": parses cronExpression and returns next occurrence after fromDate.
+ *   Cron expressions are evaluated in the trigger's optional `timezone` (an IANA
+ *   string, e.g. "America/Sao_Paulo", read defensively from the config); when
+ *   absent or invalid the timezone defaults to UTC explicitly, so behavior no
+ *   longer depends on the server/container timezone.
  *
  * Returns null if configuration is invalid or incomplete.
  */
@@ -21,15 +25,34 @@ export function computeNextRun(
   }
 
   if (config.mode === "cron") {
-    if (!config.cronExpression) return null
-    try {
-      const expr = CronExpressionParser.parse(config.cronExpression, {
-        currentDate: base,
-      })
-      return expr.next().toDate()
-    } catch {
-      return null
+    const cronExpression = config.cronExpression
+    if (!cronExpression) return null
+
+    // The shared schema doesn't declare `timezone` yet; read it defensively.
+    const rawTimezone = (config as Record<string, unknown>).timezone
+    const timezone =
+      typeof rawTimezone === "string" && rawTimezone.length > 0
+        ? rawTimezone
+        : "UTC"
+
+    const parseInTimezone = (tz: string): Date | null => {
+      try {
+        const expr = CronExpressionParser.parse(cronExpression, {
+          currentDate: base,
+          tz,
+        })
+        const next = expr.next().toDate()
+        return Number.isNaN(next.getTime()) ? null : next
+      } catch {
+        return null
+      }
     }
+
+    // Invalid timezone strings fall back to UTC rather than killing the
+    // schedule (a null here would leave nextRunAt unset forever).
+    const next = parseInTimezone(timezone)
+    if (next) return next
+    return timezone !== "UTC" ? parseInTimezone("UTC") : null
   }
 
   return null


### PR DESCRIPTION
## Summary

Fixes ~20 runtime bugs in the v1.2 Workflows feature, found by a systematic bug hunt (three parallel code-review passes + live probing against Docker) after the milestone merged. Every bug was fixed on its own isolated branch, then merged here (branches touch disjoint files, so the integration merged conflict-free). Each fix was re-verified live against Docker.

**35 files changed. `tsc` clean; full suite 451 pass / 2 pre-existing unrelated failures (formula-engine QuickJS, a deleteWorkflow mock — both fail on the untouched baseline).**

## Bugs fixed, by area

### Execution engine (`fix/execution-engine-resume` + wall-clock guard)
- **Delay as the last node looped forever** — resume fell back to node 0 and re-ran the whole workflow (re-sending emails etc.) every interval. Now completes. ✅ verified live (node ran once, run completed).
- **Delay inside a condition/split branch** skipped the merge node and everything after; **delay in split branch A** dropped branch B. Introduced a persisted `_resume` frame (which branch / pending split branch / merge point) so resume rebuilds the exact position.
- **Shared merge node double-executed** post-merge nodes (two emails per run) — `executeBranch` now stops at the merge point; the merge chain runs once.
- **No cycle guard → server-wide freeze**: a backward edge looped forever, blocking the inline processor for all workflows. Added a 1000-step cap **and a 60s wall-clock budget**. ✅ verified live: a cyclic workflow now fails in ~68s with a clear error, server stays responsive.
- **Crashed runs stuck `running` forever** blocked the workflow's queue — added a 5-min stale-run reclaim (fails, doesn't re-run) and reset `started_at` on delay resume.
- Branch-node failures now attribute the correct failing node; nested condition/split in a branch fails with a clear message instead of a cryptic dispatch error.

### Run entry points (`fix/run-entry-guards`)
- **Webhook synchronous runs were double-executed** (route ran the `pending` run while the poller also claimed it) — added an atomic `claimWorkflowRun`. ✅
- **REST `/run` ignored `active`** — inactive workflows now return 409. ✅ verified live.
- Secret comparison scans **all** webhook triggers, not just the first.

### Triggers & schedule (`fix/schedule-triggers`)
- **One failing run-creation killed all due schedules forever** (no per-loop try/catch) — now isolated per workflow, `nextRunAt` restored on failure for retry.
- Fixed `scheduledAt` envelope and interval **drift** (base time captured before the claim), added **cron timezone** support (IANA, UTC default), and preserved stage-change metadata (`oldStageId`/`newStageId`/`changedFields`) with stage filters gated to `stage_changed`.

### Save-time validation (`fix/workflow-save-validation`)
- **No config validation on save** (`validateActionConfig` was dead code) — action node configs now validated structurally on save, rejected with a node-identifying message. ✅ (unconfigured node no longer crashes at runtime with a raw TypeError).
- New action nodes get valid default configs.
- **Every save reset an interval schedule's clock** (a regression on the earlier `next_run_at` fix) — now recomputes only on a real schedule change or activation.

### REST API hardening (`fix/rest-api-hardening`)
- Pagination clamped (max 100) and NaN-safe (`?limit=abc` was a 500, now 200). ✅ verified live.
- Trigger payloads validated against the real `triggersArraySchema` (bad shapes no longer silently disable a trigger).
- **Webhook secrets redacted** from list/get responses. ✅ verified live.
- REST deal events now emit the same camelCase shape as the UI path (consistent `{{trigger.data.*}}`).
- Handlers wrapped in RFC7807 errors.

### Action handlers (`fix/action-handlers`)
- **crm_action couldn't set numeric/date fields** ("expected number, received string") — now coerces string values to the field's type. ✅ verified live (deal value set to `9999`).
- `lookupField` is now a per-entity dropdown matching the handler whitelist.
- **GET/HEAD requests with a body threw** (undici) — body omitted for GET/HEAD; two built-in GET templates fixed.

### webhook_response & robustness (`fix/webhook-response-body`, `fix/small-robustness`)
- **webhook_response body was delivered as character-indexed garbage** (`{"0":"{",...}`) — the form now stores/handler now emits a real JSON object. ✅ verified live (returned `{"success":true,"msg":"hi"}`, HTTP 201).
- Transform help text now documents the **actual** sandbox API (`input`, `console.log`, MATH/TEXT/DATE/LOGIC) instead of non-existent `helpers`/`output` globals.
- A condition with an empty field path no longer crashes the run.

## Verification

Each fix has unit tests (added by its agent). Live re-verification against Docker on the integrated branch confirmed: webhook_response JSON, delay-last completes, crm numeric coercion, `/run` 409 on inactive, pagination NaN/clamp, secret redaction, and the cycle guard failing in ~60s.

## Known follow-ups (out of scope, low)
- `listWorkflows`/`getWorkflow` lack per-owner scoping (any API key sees all workflows) — needs mutation-level filtering; noted with a TODO in the routes.
- Nested condition/split inside a branch is rejected rather than supported (v1 limitation, clear error).
- vitest globs stale `.next/standalone` test copies (test-config nit, not shipped code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
