### PR TITLE
Fix workflow REST API ownership scoping

### DIFF
--- a/src/app/api/v1/workflows/[id]/route.ts
+++ b/src/app/api/v1/workflows/[id]/route.ts
@@ -24,11 +24,8 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     try {
       const { id } = await params
 
-      // TODO(scoping): getWorkflow (src/lib/mutations/workflows.ts) does not
-      // check ownership, so any valid API key can read any workflow by id.
-      // Ownership scoping must be decided/added at the mutation level to stay
-      // consistent with the UI, which shares these mutations.
-      const workflow = await getWorkflow(id)
+      // Scope by owner: a non-owner gets 404 (not another user's workflow).
+      const workflow = await getWorkflow(id, context.userId)
 
       if (!workflow) {
         return Problems.notFound("Workflow")
@@ -66,6 +63,12 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
         return Problems.validation(errors)
       }
 
+      // Ownership gate: reject updates to workflows the caller doesn't own.
+      const owned = await getWorkflow(id, context.userId)
+      if (!owned) {
+        return Problems.notFound("Workflow")
+      }
+
       const result = await updateWorkflow(id, parseResult.data)
 
       if (!result.success) {
@@ -84,6 +87,12 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
   return withApiAuth(request, async (req: NextRequest, context: ApiAuthContext) => {
     try {
       const { id } = await params
+
+      // Ownership gate: reject deletes of workflows the caller doesn't own.
+      const owned = await getWorkflow(id, context.userId)
+      if (!owned) {
+        return Problems.notFound("Workflow")
+      }
 
       const result = await deleteWorkflow(id)
 

--- a/src/app/api/v1/workflows/[id]/run/route.ts
+++ b/src/app/api/v1/workflows/[id]/run/route.ts
@@ -19,8 +19,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   return withApiAuth(request, async (req: NextRequest, context: ApiAuthContext) => {
     const { id } = await params
 
-    // Look up workflow
-    const workflow = await getWorkflow(id)
+    // Look up workflow, scoped to the authed user so a non-owner can't run
+    // (or probe the existence of) another user's workflow.
+    const workflow = await getWorkflow(id, context.userId)
     if (!workflow) {
       return Problems.notFound("Workflow")
     }

--- a/src/app/api/v1/workflows/route.ts
+++ b/src/app/api/v1/workflows/route.ts
@@ -20,11 +20,9 @@ export async function GET(request: NextRequest) {
     try {
       const { offset, limit } = parsePagination(req)
 
-      // TODO(scoping): listWorkflows (src/lib/mutations/workflows.ts) does not
-      // filter by owner, so any valid API key sees every workflow. Ownership
-      // scoping must be added at the mutation level (it also affects the UI
-      // list); filtering here after the fact would break pagination totals.
-      const result = await listWorkflows({ offset, limit })
+      // Scope to the authed user so one API key can't enumerate another
+      // user's workflows (consistent with the deals API's owner scoping).
+      const result = await listWorkflows({ offset, limit, createdBy: context.userId })
 
       const data = result.workflows.map(serializeWorkflow)
 

--- a/src/lib/mutations/workflows.test.ts
+++ b/src/lib/mutations/workflows.test.ts
@@ -490,7 +490,9 @@ describe("listWorkflows", () => {
 
     mockDb.query.workflows.findMany.mockResolvedValue(mockWorkflows)
     mockDb.select.mockReturnValue({
-      from: vi.fn().mockReturnValue([{ total: 2 }]),
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue([{ total: 2 }]),
+      }),
     })
 
     const result = await listWorkflows({ offset: 0, limit: 50 })
@@ -499,5 +501,22 @@ describe("listWorkflows", () => {
       workflows: mockWorkflows,
       total: 2,
     })
+  })
+
+  it("scopes the query to the owner when createdBy is provided", async () => {
+    mockDb.query.workflows.findMany.mockResolvedValue([])
+    const whereSpy = vi.fn().mockReturnValue([{ total: 0 }])
+    mockDb.select.mockReturnValue({
+      from: vi.fn().mockReturnValue({ where: whereSpy }),
+    })
+
+    await listWorkflows({ offset: 0, limit: 50, createdBy: "user-1" })
+
+    // Count query filtered by owner...
+    expect(whereSpy).toHaveBeenCalledWith(expect.anything())
+    // ...and the row query too (a defined `where` means the owner filter applied).
+    expect(mockDb.query.workflows.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.anything() })
+    )
   })
 })

--- a/src/lib/mutations/workflows.ts
+++ b/src/lib/mutations/workflows.ts
@@ -1,6 +1,6 @@
 import { db } from "@/db"
 import { workflows, workflowRuns, workflowRunSteps } from "@/db/schema/workflows"
-import { eq, desc, count, inArray } from "drizzle-orm"
+import { eq, desc, count, inArray, and } from "drizzle-orm"
 import { z } from "zod"
 import type { Workflow } from "@/db/schema/workflows"
 import { generateWebhookSecret } from "@/lib/triggers/webhook-secret"
@@ -214,9 +214,20 @@ export async function deleteWorkflow(id: string): Promise<DeleteResult> {
   return { success: true }
 }
 
-export async function getWorkflow(id: string): Promise<Workflow | null> {
+/**
+ * Fetch a workflow by id. When `createdBy` is provided, the workflow is only
+ * returned if that user owns it — callers use this as an ownership gate so a
+ * non-owner gets `null` (and, at the API layer, a 404) instead of another
+ * user's workflow. Omit `createdBy` for trusted server-side callers.
+ */
+export async function getWorkflow(
+  id: string,
+  createdBy?: string
+): Promise<Workflow | null> {
   const workflow = await db.query.workflows.findFirst({
-    where: eq(workflows.id, id),
+    where: createdBy
+      ? and(eq(workflows.id, id), eq(workflows.createdBy, createdBy))
+      : eq(workflows.id, id),
   })
 
   return workflow ?? null
@@ -269,15 +280,22 @@ export async function regenerateWebhookSecret(
 }
 
 export async function listWorkflows(
-  options: { offset?: number; limit?: number } = {}
+  options: { offset?: number; limit?: number; createdBy?: string } = {}
 ): Promise<{ workflows: Workflow[]; total: number }> {
-  const { offset = 0, limit = 50 } = options
+  const { offset = 0, limit = 50, createdBy } = options
+
+  // Scope to the owner when provided (API callers pass the authed user) so one
+  // user can't enumerate another's workflows; total must reflect the same
+  // filter or pagination reports counts the caller can't actually see.
+  const ownerFilter = createdBy ? eq(workflows.createdBy, createdBy) : undefined
 
   const [{ total }] = await db
     .select({ total: count() })
     .from(workflows)
+    .where(ownerFilter)
 
   const results = await db.query.workflows.findMany({
+    where: ownerFilter,
     orderBy: desc(workflows.createdAt),
     offset,
     limit,


### PR DESCRIPTION
## Summary

Closes the ownership-scoping follow-up flagged in #8: the workflow REST API had no owner filter, so any valid API key could **list, read, run, update, or delete every user's workflows**. The deals API already scopes by owner (`ownerId == context.userId`); this brings workflows in line (workflows own via `createdBy`).

## Changes
- `listWorkflows` / `getWorkflow` (`src/lib/mutations/workflows.ts`) take an optional `createdBy` filter. `listWorkflows` applies it to **both** the row query and the count (so pagination totals match what the caller can see); `getWorkflow` returns `null` for a non-owner. Server-side/UI callers omit the arg and are unchanged.
- `GET /api/v1/workflows` scopes the list to `context.userId`.
- `GET`, `PUT`, `DELETE /api/v1/workflows/{id}` and `POST /{id}/run` gate on `getWorkflow(id, context.userId)` → **404** for non-owners (no existence leak, no cross-user mutation).
- Removed the two `TODO(scoping)` comments left in #8.

## Verification
- `tsc` clean. `workflows.test.ts`: 21 pass + new scoping assertion (only the known pre-existing `deleteWorkflow` mock failure remains).
- Live (two users): admin key lists only its own workflow (total 1, not the other user's); GET/RUN/PUT/DELETE on the other user's workflow all return **404** and leave it untouched; the admin's own workflow returns **200**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
